### PR TITLE
Vd minion multiuser and new juicer protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ language: python
 python:
   - "2.7"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: 
+   - pip install -r requirements.txt
+   - cd /tmp
+   - wget http://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.6.tgz
+   - tar xf spark-2.1.0-bin-hadoop2.6.tgz && mv spark-2.1.0-bin-hadoop2.6 spark
+   - export SPARK_HOME=/tmp/spark
+   - export PYTHONPATH=$SPARK_HOME/python:$PYTHONPATH
 # command to run tests
 script: pytest
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ python:
 # command to install dependencies
 install: 
    - pip install -r requirements.txt
-   - cd /tmp
    - wget http://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.6.tgz
    - tar xf spark-2.1.0-bin-hadoop2.6.tgz && mv spark-2.1.0-bin-hadoop2.6 spark
-   - export SPARK_HOME=/tmp/spark
+   - export SPARK_HOME=$(pwd)/spark
    - export PYTHONPATH=$SPARK_HOME/python:$PYTHONPATH
 # command to run tests
 script: pytest

--- a/juicer/runner/control.py
+++ b/juicer/runner/control.py
@@ -5,11 +5,11 @@ class StateControlRedis:
     state they keep.
     For workflows, it is important to avoid running them twice.
     Job queue is used to control which commands minions should execute.
-    Finally, job output queues contains messages from minions to be sent to
+    Finally, app output queues contains messages from minions to be sent to
     user interface.
     """
     START_QUEUE_NAME = 'queue_start'
-    QUEUE_JOB = 'queue_job_{}'
+    QUEUE_JOB = 'queue_app_{}'
 
     def __init__(self, redis_conn):
         self.redis_conn = redis_conn
@@ -30,14 +30,14 @@ class StateControlRedis:
     def push_start_queue(self, data):
         self.push_queue(self.START_QUEUE_NAME, data)
 
-    def pop_job_queue(self, job_id, block=True):
-        return self.pop_queue(self.QUEUE_JOB.format(job_id), block)
+    def pop_app_queue(self, app_id, block=True):
+        return self.pop_queue(self.QUEUE_JOB.format(app_id), block)
 
-    def push_job_queue(self, job_id, data):
-        self.push_queue(self.QUEUE_JOB.format(job_id), data)
+    def push_app_queue(self, app_id, data):
+        self.push_queue(self.QUEUE_JOB.format(app_id), data)
 
-    def get_job_queue_size(self, job_id):
-        key = self.QUEUE_JOB.format(job_id)
+    def get_app_queue_size(self, app_id):
+        key = self.QUEUE_JOB.format(app_id)
         return self.redis_conn.llen(key)
 
     def get_workflow_status(self, workflow_id):
@@ -52,28 +52,28 @@ class StateControlRedis:
         key = 'record_workflow_{}'.format(workflow_id)
         return self.redis_conn.hgetall(key)
 
-    def get_minion_status(self, job_id):
-        key = 'key_minion_job_{}'.format(job_id)
+    def get_minion_status(self, app_id):
+        key = 'key_minion_app_{}'.format(app_id)
         return self.redis_conn.get(key)
 
-    def set_minion_status(self, job_id, status, ex=30, nx=True):
-        key = 'key_minion_job_{}'.format(job_id)
+    def set_minion_status(self, app_id, status, ex=30, nx=True):
+        key = 'key_minion_app_{}'.format(app_id)
         return self.redis_conn.set(key, status, ex=ex, nx=nx)
 
-    def pop_job_output_queue(self, job_id, block=True):
-        key = 'queue_output_job_{job_id}'.format(job_id=job_id)
+    def pop_app_output_queue(self, app_id, block=True):
+        key = 'queue_output_app_{app_id}'.format(app_id=app_id)
         if block:
             result = self.redis_conn.blpop(key)[1]
         else:
             result = self.redis_conn.lpop(key)
         return result
 
-    def push_job_output_queue(self, job_id, data):
-        key = 'queue_output_job_{job_id}'.format(job_id=job_id)
+    def push_app_output_queue(self, app_id, data):
+        key = 'queue_output_app_{app_id}'.format(app_id=app_id)
         self.redis_conn.rpush(key, data)
 
-    def get_job_output_queue_size(self, job_id):
-        key = 'queue_output_job_{job_id}'.format(job_id=job_id)
+    def get_app_output_queue_size(self, app_id):
+        key = 'queue_output_app_{app_id}'.format(app_id=app_id)
         return self.redis_conn.llen(key)
 
     def pop_master_queue(self, block=True):
@@ -92,18 +92,18 @@ class StateControlRedis:
         key = 'queue_master'
         return self.redis_conn.llen(key)
 
-    def pop_job_delivery_queue(self, job_id, block=True):
-        key = 'queue_delivery_job_{job_id}'.format(job_id=job_id)
+    def pop_app_delivery_queue(self, app_id, block=True):
+        key = 'queue_delivery_app_{app_id}'.format(app_id=app_id)
         if block:
             result = self.redis_conn.blpop(key)[1]
         else:
             result = self.redis_conn.lpop(key)
         return result
 
-    def push_job_delivery_queue(self, job_id, data):
-        key = 'queue_delivery_job_{job_id}'.format(job_id=job_id)
+    def push_app_delivery_queue(self, app_id, data):
+        key = 'queue_delivery_app_{app_id}'.format(app_id=app_id)
         self.redis_conn.rpush(key, data)
 
-    def get_job_delivery_queue_size(self, job_id):
-        key = 'queue_delivery_job_{job_id}'.format(job_id=job_id)
+    def get_app_delivery_queue_size(self, app_id):
+        key = 'queue_delivery_app_{app_id}'.format(app_id=app_id)
         return self.redis_conn.llen(key)

--- a/juicer/runner/control.py
+++ b/juicer/runner/control.py
@@ -9,7 +9,7 @@ class StateControlRedis:
     user interface.
     """
     START_QUEUE_NAME = 'queue_start'
-    QUEUE_JOB = 'queue_app_{}'
+    QUEUE_APP = 'queue_app_{}'
 
     def __init__(self, redis_conn):
         self.redis_conn = redis_conn
@@ -31,13 +31,13 @@ class StateControlRedis:
         self.push_queue(self.START_QUEUE_NAME, data)
 
     def pop_app_queue(self, app_id, block=True):
-        return self.pop_queue(self.QUEUE_JOB.format(app_id), block)
+        return self.pop_queue(self.QUEUE_APP.format(app_id), block)
 
     def push_app_queue(self, app_id, data):
-        self.push_queue(self.QUEUE_JOB.format(app_id), data)
+        self.push_queue(self.QUEUE_APP.format(app_id), data)
 
     def get_app_queue_size(self, app_id):
-        key = self.QUEUE_JOB.format(app_id)
+        key = self.QUEUE_APP.format(app_id)
         return self.redis_conn.llen(key)
 
     def get_workflow_status(self, workflow_id):

--- a/juicer/runner/juicer_client.py
+++ b/juicer/runner/juicer_client.py
@@ -1,0 +1,93 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+import argparse
+import urlparse
+import logging
+import pdb
+
+import redis
+import requests
+from juicer.runner.control import StateControlRedis
+from six import StringIO
+
+# eventlet.monkey_patch()
+import json
+
+logging.basicConfig(
+    format='[%(levelname)s] %(asctime)s,%(msecs)05.1f (%(funcName)s) %(message)s',
+    datefmt='%H:%M:%S')
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
+
+
+class JuicerClient:
+    def __init__(self, redis_conn,
+            workflow_id, app_id, app_configs={}, terminate=False):
+        self.redis_conn = redis_conn
+        self.workflow_id = workflow_id
+        self.app_id = app_id
+        self.app_configs = app_configs
+        self.terminate = terminate
+
+    def run(self):
+        log.debug('Processing workflow queue %s', self.workflow_id)
+        state_control = StateControlRedis(self.redis_conn)
+        request_url = "http://beta.ctweb.inweb.org.br/tahiti/workflows/{}?token=123456".format(self.workflow_id)
+        workflow_json = requests.get(request_url).text
+
+        app_submission = {
+                "workflow_id": self.workflow_id,
+                "app_id": self.app_id,
+                "app_configs": self.app_configs,
+                "terminate": "true" if self.terminate else "false"
+                }
+
+        print workflow_json
+        workflow_dict = json.loads(workflow_json)
+        app_submission['workflow'] = workflow_dict
+        app_submission_json = json.dumps(app_submission)
+        print app_submission
+        print app_submission_json
+        
+        state_control.push_start_queue(json.dumps(app_submission))
+
+def main(redisserver, workflow_id, app_id, appconfigs, terminate):
+    # redis server parsing
+    parsed_url = urlparse.urlparse(redisserver)
+    redis_conn = redis.StrictRedis(host=parsed_url.hostname,
+            port=parsed_url.port)
+
+    # app configs (spark) 'config1=value1,config2=value2, ...'
+    if appconfigs:
+        app_configs = [kv.split("=") for kv in appconfigs.split("=")]
+        app_configs = {kv[0]:kv[1] for kv in app_configs}
+    else:
+        app_configs = {}
+
+    client = JuicerClient(redis_conn,
+            workflow_id, app_id, app_configs, terminate)
+    client.run()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    
+    parser.add_argument("-r", "--redis_server", default="redis://127.0.0.1:6379",
+            help="Please inform the redis server url redis://<host>:<port>")
+    
+    parser.add_argument("-w", "--workflow_id", type=str, required=True,
+            help="Workflow identification number")
+    
+    parser.add_argument("-a", "--app_id", type=str, required=True,
+            help="Application identification number")
+    
+    parser.add_argument("-c", "--app_configs", type=str, default="",
+            help="Key value configuration for the spark application")
+
+    parser.add_argument("-t", "--terminate", type=bool, default=False,
+            help="terminate the context identified by (workflowid,appid)")
+
+    args = parser.parse_args()
+    print args
+
+    main(args.redis_server,
+            args.workflow_id, args.app_id, args.app_configs, args.terminate)

--- a/juicer/runner/juicer_client.py
+++ b/juicer/runner/juicer_client.py
@@ -42,12 +42,11 @@ class JuicerClient:
                 "terminate": "true" if self.terminate else "false"
                 }
 
-        print workflow_json
+	print app_submission
+
         workflow_dict = json.loads(workflow_json)
         app_submission['workflow'] = workflow_dict
         app_submission_json = json.dumps(app_submission)
-        print app_submission
-        print app_submission_json
         
         state_control.push_start_queue(json.dumps(app_submission))
 
@@ -59,7 +58,7 @@ def main(redisserver, workflow_id, app_id, appconfigs, terminate):
 
     # app configs (spark) 'config1=value1,config2=value2, ...'
     if appconfigs:
-        app_configs = [kv.split("=") for kv in appconfigs.split("=")]
+        app_configs = [kv.split("=") for kv in appconfigs.split(",")]
         app_configs = {kv[0]:kv[1] for kv in app_configs}
     else:
         app_configs = {}
@@ -87,7 +86,6 @@ if __name__ == "__main__":
             help="terminate the context identified by (workflowid,appid)")
 
     args = parser.parse_args()
-    print args
 
     main(args.redis_server,
             args.workflow_id, args.app_id, args.app_configs, args.terminate)

--- a/juicer/runner/juicer_protocol.py
+++ b/juicer/runner/juicer_protocol.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+
+## Comm protocol between clients, JuicerServer and Minion ##
+
+# EXECUTE messages request the execution of a new job
+# {
+#   'workflow_id': <workflow identifier>
+#   'app_id': <app identifier, representing an workflow instance>
+#   'type': 'execute'
+#   'app_configs': <key value pairs as app resource and env configurations>
+#   'workflow': <workflow that will be transpiled and executed>
+# }
+EXECUTE = 'execute'
+
+# DELIVER messages request the delivery of a result (task_id)
+# {
+#   'workflow_id': <workflow identifier>
+#   'app_id': <app identifier, representing an workflow instance>
+#   'type': 'deliver'
+#   'task_id': <identifier of the task result to deliver>
+#   'output': <queue identifier for publishing results>
+#   'port': <port for fetching results>
+#   'app_configs': <key value pairs as app resource and env configurations>
+#   'workflow': <workflow that will be transpiled and executed>
+# }
+DELIVER = 'deliver'
+
+# TERMINATE messages request the termination of a minion
+# {
+#   'workflow_id': <workflow identifier>
+#   'app_id': <app identifier, representing an workflow instance>
+#   'type': 'terminate'
+# }
+TERMINATE = 'terminate'
+
+

--- a/juicer/runner/juicer_server.py
+++ b/juicer/runner/juicer_server.py
@@ -98,13 +98,15 @@ class JuicerServer:
             
             # Get minion status, if it exists
             minion_info = state_control.get_minion_status(app_id)
-            log.debug('Minion status for app %s: %s', app_id, minion_info)
+            log.debug('Minion status for (workflow_id=%s,app_id=%s): %s',
+		workflow_id, app_id, minion_info)
 
             # If there is status registered for the application then we do not
             # need to launch a minion for it, because it is already running.
             # Otherwise, we launch a new minion for the application.
             if minion_info:
-                log.debug('Minion %s is running.', 'minion_{}'.format(app_id))
+                log.debug('Minion (workflow_id=%s,app_id=%s) is running.',
+			workflow_id, app_id)
             else:
                 minion_process = self._start_minion(
                         workflow_id, app_id, state_control)
@@ -116,7 +118,8 @@ class JuicerServer:
             state_control.push_app_queue(app_id, msg)
             state_control.set_workflow_status(workflow_id, self.STARTED)
 
-            log.info('Generating code for app %s', app_id)
+            log.info('Generating code for (workflow_id=%s,app_id=%s)',
+		workflow_id, app_id)
             state_control.push_app_output_queue(app_id, json.dumps(
                 {'code': 0, 'message': 'Workflow will start soon'}))
 
@@ -133,7 +136,7 @@ class JuicerServer:
 
     def _start_minion(self, workflow_id, app_id, state_control, restart=False):
 
-        minion_id = 'minion_{}'.format(app_id)
+        minion_id = 'minion_{}_{}'.format(workflow_id, app_id)
         stdout_log = os.path.join(self.log_dir, minion_id + '_out.log')
         stderr_log = os.path.join(self.log_dir, minion_id + '_err.log')
         log.debug('Forking minion %s.', minion_id)

--- a/juicer/runner/juicer_server.py
+++ b/juicer/runner/juicer_server.py
@@ -26,13 +26,16 @@ logging.basicConfig(
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
-
 class JuicerServer:
     """
-    Server
+    The JuicerServer is responsible for managing the lifecycle of minions.
+    A minion controls a application, i.e., an active instance of an workflow.
+    Thus, the JuicerServer receives launch request from clients, launches and
+    manages minion processes and takes care of their properly termination.
     """
     STARTED = 'STARTED'
     LOADED = 'LOADED'
+    TERMINATION_PILL = 'terminate'
     HELP_UNHANDLED_EXCEPTION = 1
     HELP_STATE_LOST = 2
 
@@ -43,21 +46,21 @@ class JuicerServer:
         self.start_process = None
         self.minion_status_process = None
 
+        self.active_minions = {}
+
         self.config = config
         self.config_file_path = config_file_path
         self.minion_executable = minion_executable
-        self.log_dir = log_dir
+        self.log_dir = log_dir or \
+                self.config['juicer'].get('log', {}).get('path', '/tmp')
 
     def start(self):
         log.info('Starting master process. Reading "start" queue ')
-        minions_executable = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), 'minion.py'))
-        log_dir = self.config['juicer'].get('log', {}).get('path', '/tmp')
 
         parsed_url = urlparse.urlparse(
             self.config['juicer']['servers']['redis_url'])
         redis_conn = redis.StrictRedis(host=parsed_url.hostname,
-                                       port=parsed_url.port)
+            port=parsed_url.port)
 
         while True:
             self.read_start_queue(redis_conn)
@@ -65,62 +68,89 @@ class JuicerServer:
     # noinspection PyMethodMayBeStatic
     def read_start_queue(self, redis_conn):
 
+        # Process next message
         state_control = StateControlRedis(redis_conn)
         msg = state_control.pop_start_queue()
-
         item = json.loads(msg)
-        job_id = item.get('job_id')
+        app_id = item.get('app_id')
+        workflow_id = item['workflow_id']
+
         try:
-            if job_id is None:
-                raise ValueError('Job id not informed')
-            minion_id = 'minion_{}'.format(job_id)
+            if app_id is None:
+                raise ValueError('Application id not informed')
+            elif item.get(self.TERMINATION_PILL, 'false').lower() in ('true'):
+                # In this case we got a request for terminating this workflow
+                # execution instance (app). Thus, we are going to explicitly
+                # terminate the workflow, clear any remaining metadata and return
+                assert app_id in self.active_minions
+                log.debug("Received termination pill for app %s", app_id)
+                os.kill(self.active_minions[app_id].pid, signal.SIGTERM)
+                del self.active_minions[app_id]
+                return
 
-            if state_control.get_workflow_status(
-                    item['workflow_id']) == JuicerServer.STARTED:
-                raise JuicerException('Workflow is already started', code=1000)
-            # Is minioon running?
-            minion_info = state_control.get_minion_status(job_id)
+            # NOTE: Currently we are assuming that clients will only submit one
+            # workflow at a time. Such assumption implies that both workflow_id
+            # and app_id must be individually unique in this server at any point
+            # of time. We plan to change that in the future, by allowing
+            # multiple instances of the same workflow to be launched
+            # concurrently.
+            if self.active_minions.get(app_id, None) and \
+                    state_control.get_workflow_status(workflow_id) != self.STARTED:
+                raise JuicerException('Workflow {} should be started'.format(
+                    workflow_id), code=1000)
+            
+            # Get minion status, if it exists
+            minion_info = state_control.get_minion_status(app_id)
+            log.debug('Minion status for app %s: %s', app_id,
+                    state_control.get_minion_status(app_id))
 
+            # If there is status registered for the application then we do not
+            # need to launch a minion for it, because it is already running.
+            # Otherwise, we launch a new minion for the application.
             if minion_info:
-                log.debug('Minion %s is running.', minion_id)
+                log.debug('Minion %s is running.', 'minion_{}'.format(app_id))
             else:
-                self._start_minion(job_id, state_control)
+                minion_process = self._start_minion(app_id, state_control)
+                self.active_minions[app_id] = minion_process
+            
+            # Make the message (workflow partial execution) visible to the
+            # minion, which will pop this set of commands and submit to the
+            # underlying spark context
+            state_control.push_app_queue(app_id, msg)
+            state_control.set_workflow_status(workflow_id, self.STARTED)
 
-            # requeue message to minion processing
-            state_control.push_job_queue(job_id, msg)
-            state_control.set_workflow_status(item['workflow_id'], self.STARTED)
-
-            log.info('Generating code for job %s', job_id)
-            state_control.push_job_output_queue(job_id, json.dumps(
+            log.info('Generating code for app %s', app_id)
+            state_control.push_app_output_queue(app_id, json.dumps(
                 {'code': 0, 'message': 'Workflow will start soon'}))
 
         except JuicerException as je:
             log.error(je)
-            if job_id:
-                state_control.push_job_output_queue(job_id, json.dumps(
+            if app_id:
+                state_control.push_app_output_queue(app_id, json.dumps(
                     {'code': je.code, 'message': je.message}))
         except Exception as ex:
             log.error(ex)
-            if job_id:
-                state_control.push_job_output_queue(
-                    job_id, json.dumps({'code': 500, 'message': ex.message}))
-                # raise
+            if app_id:
+                state_control.push_app_output_queue(
+                    app_id, json.dumps({'code': 500, 'message': ex.message}))
 
-    def _start_minion(self, job_id, state_control, restart=False):
+    def _start_minion(self, app_id, state_control, restart=False):
 
-        minion_id = 'minion_{}'.format(job_id)
+        minion_id = 'minion_{}'.format(app_id)
         stdout_log = os.path.join(self.log_dir, minion_id + '_out.log')
         stderr_log = os.path.join(self.log_dir, minion_id + '_err.log')
-
         log.debug('Forking minion %s.', minion_id)
 
         # Expires in 30 seconds and sets only if it doesn't exist
-        state_control.set_minion_status(job_id, self.STARTED, ex=30,
-                                        nx=restart)
+        state_control.set_minion_status(app_id,
+                self.STARTED, ex=30, nx=False)
+
+        # Setup command and launch the minion script. We return the subprocess
+        # created as part of an active minion.
         open_opts = ['nohup', sys.executable, self.minion_executable,
-                     '-j', job_id, '-c', self.config_file_path]
-        subprocess.Popen(open_opts, stdout=open(stdout_log, 'a'),
-                         stderr=open(stderr_log, 'a'))
+                '-a', app_id, '-c', self.config_file_path]
+        return subprocess.Popen(open_opts,
+                stdout=open(stdout_log, 'a'), stderr=open(stderr_log, 'a'))
 
     def minion_support(self):
         parsed_url = urlparse.urlparse(
@@ -134,13 +164,13 @@ class JuicerServer:
         try:
             state_control = StateControlRedis(redis_conn)
             ticket = json.loads(state_control.pop_master_queue())
-            job_id = ticket.get('job_id')
+            app_id = ticket.get('app_id')
             reason = ticket.get('reason')
-            log.info("Master received a ticket for job %s", job_id)
+            log.info("Master received a ticket for app %s", app_id)
             if reason == self.HELP_UNHANDLED_EXCEPTION:
                 # Let's kill the minion and start another
                 minion_info = json.loads(
-                    state_control.get_minion_status(job_id))
+                    state_control.get_minion_status(app_id))
                 while True:
                     try:
                         os.kill(minion_info['pid'], signal.SIGKILL)
@@ -149,7 +179,7 @@ class JuicerServer:
                             break
                     time.sleep(.5)
 
-                self._start_minion(job_id, state_control)
+                self._start_minion(app_id, state_control)
 
             elif reason == self.HELP_STATE_LOST:
                 pass
@@ -172,7 +202,7 @@ class JuicerServer:
         pubsub.psubscribe('__keyevent@*__:expired')
         for msg in pubsub.listen():
             if msg.get('type') == 'pmessage' and 'minion' in msg.get('data'):
-                log.warn('Minion {id} stoped'.format(id=msg.get('data')))
+                log.warn('Minion {id} stopped'.format(id=msg.get('data')))
 
     def process(self):
         self.start_process = multiprocessing.Process(
@@ -200,6 +230,11 @@ if __name__ == '__main__':
     with open(args.config) as config_file:
         juicer_config = yaml.load(config_file.read())
 
+    # Every minion starts with the same script.
+    minion_executable = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), 'minion.py'))
+
     log.info('Starting Juicer Server')
-    server = JuicerServer(juicer_config, args.config)
+    server = JuicerServer(juicer_config, minion_executable,
+            config_file_path=args.config)
     server.process()

--- a/juicer/runner/juicer_server.py
+++ b/juicer/runner/juicer_server.py
@@ -17,6 +17,7 @@ import os
 import redis
 import yaml
 from juicer.exceptions import JuicerException
+from juicer.runner import juicer_protocol
 from juicer.runner.control import StateControlRedis
 
 logging.basicConfig(
@@ -35,16 +36,16 @@ class JuicerServer:
     """
     STARTED = 'STARTED'
     LOADED = 'LOADED'
-    TERMINATION_PILL = 'terminate'
     HELP_UNHANDLED_EXCEPTION = 1
     HELP_STATE_LOST = 2
-
+    
     def __init__(self, config, minion_executable, log_dir='/tmp',
                  config_file_path=None):
 
         self.minion_support_process = None
         self.start_process = None
         self.minion_status_process = None
+        self.state_control = None
 
         self.active_minions = {}
 
@@ -67,72 +68,81 @@ class JuicerServer:
 
     # noinspection PyMethodMayBeStatic
     def read_start_queue(self, redis_conn):
-
+        self.state_control = StateControlRedis(redis_conn)
         # Process next message
-        state_control = StateControlRedis(redis_conn)
-        msg = state_control.pop_start_queue()
-        item = json.loads(msg)
+        msg = self.state_control.pop_start_queue()
+        msg_info = json.loads(msg)
+
+        # Extract message type and common parameters
+        msg_type = msg_info['type']
+        workflow_id = app_id = None
 
         try:
-            app_id = item.get('app_id')
-            workflow_id = item.get('workflow_id')
-            app_id = str(app_id) if app_id else None
-            workflow_id = str(workflow_id) if workflow_id else None
-
-            if app_id is None:
-                raise ValueError('Application id not informed')
-            elif item.get(self.TERMINATION_PILL, 'false').lower() in ('true'):
-                self._terminate_minion(app_id)
-                return
-
+            workflow_id = str(msg_info['workflow_id'])
+            app_id = str(msg_info['app_id'])
             # NOTE: Currently we are assuming that clients will only submit one
             # workflow at a time. Such assumption implies that both workflow_id
             # and app_id must be individually unique in this server at any point
             # of time. We plan to change that in the future, by allowing
             # multiple instances of the same workflow to be launched
             # concurrently.
-            if self.active_minions.get(app_id, None) and \
-                    state_control.get_workflow_status(workflow_id) != self.STARTED:
+            if self.active_minions.get((workflow_id, app_id), None) and \
+                    self.state_control.get_workflow_status(workflow_id) != self.STARTED:
                 raise JuicerException('Workflow {} should be started'.format(
                     workflow_id), code=1000)
             
-            # Get minion status, if it exists
-            minion_info = state_control.get_minion_status(app_id)
-            log.debug('Minion status for (workflow_id=%s,app_id=%s): %s',
-		workflow_id, app_id, minion_info)
+            if msg_type in (juicer_protocol.EXECUTE, juicer_protocol.DELIVER):
+                self._forward_to_minion(msg_type, workflow_id, app_id, msg)
 
-            # If there is status registered for the application then we do not
-            # need to launch a minion for it, because it is already running.
-            # Otherwise, we launch a new minion for the application.
-            if minion_info:
-                log.debug('Minion (workflow_id=%s,app_id=%s) is running.',
-			workflow_id, app_id)
+            elif msg_type == juicer_protocol.TERMINATE:
+                self._terminate_minion(workflow_id, app_id)
+
             else:
-                minion_process = self._start_minion(
-                        workflow_id, app_id, state_control)
-                self.active_minions[app_id] = minion_process
+                log.warn('Unknown message type %s', msg_type)
             
-            # Make the message (workflow partial execution) visible to the
-            # minion, which will pop this set of commands and submit to the
-            # underlying spark context
-            state_control.push_app_queue(app_id, msg)
-            state_control.set_workflow_status(workflow_id, self.STARTED)
-
-            log.info('Generating code for (workflow_id=%s,app_id=%s)',
-		workflow_id, app_id)
-            state_control.push_app_output_queue(app_id, json.dumps(
-                {'code': 0, 'message': 'Workflow will start soon'}))
-
         except JuicerException as je:
             log.error(je)
             if app_id:
-                state_control.push_app_output_queue(app_id, json.dumps(
+                self.state_control.push_app_output_queue(app_id, json.dumps(
                     {'code': je.code, 'message': je.message}))
+
         except Exception as ex:
             log.error(ex)
             if app_id:
-                state_control.push_app_output_queue(
+                self.state_control.push_app_output_queue(
                     app_id, json.dumps({'code': 500, 'message': ex.message}))
+
+    def _forward_to_minion(self, msg_type, workflow_id, app_id, msg):
+        # Get minion status, if it exists
+        minion_info = self.state_control.get_minion_status(app_id)
+        log.debug('Minion status for (workflow_id=%s,app_id=%s): %s',
+            workflow_id, app_id, minion_info)
+
+        # If there is status registered for the application then we do not
+        # need to launch a minion for it, because it is already running.
+        # Otherwise, we launch a new minion for the application.
+        if minion_info:
+            log.debug('Minion (workflow_id=%s,app_id=%s) is running.',
+                    workflow_id, app_id)
+        else:
+            # This is a special case when the minion timed out.
+            # In this case we kill it before starting a new one
+            if (workflow_id,app_id) in self.active_minions:
+                self._terminate_minion(workflow_id, app_id)
+
+            minion_process = self._start_minion(
+                    workflow_id, app_id, self.state_control)
+            self.active_minions[(workflow_id,app_id)] = minion_process
+        
+        # Forward the message to the minion, which can be an execute or a
+        # deliver command
+        self.state_control.push_app_queue(app_id, msg)
+        self.state_control.set_workflow_status(workflow_id, self.STARTED)
+
+        log.info('Message %s forwarded to minion (workflow_id=%s,app_id=%s)',
+            msg_type, workflow_id, app_id)
+        self.state_control.push_app_output_queue(app_id, json.dumps(
+            {'code': 0, 'message': 'Minion is processing message %s' % msg_type}))
 
     def _start_minion(self, workflow_id, app_id, state_control, restart=False):
 
@@ -151,14 +161,15 @@ class JuicerServer:
         return subprocess.Popen(open_opts,
                 stdout=open(stdout_log, 'a'), stderr=open(stderr_log, 'a'))
 
-    def _terminate_minion(self, app_id):
+    def _terminate_minion(self, workflow_id, app_id):
         # In this case we got a request for terminating this workflow
         # execution instance (app). Thus, we are going to explicitly
         # terminate the workflow, clear any remaining metadata and return
-        assert app_id in self.active_minions
-        log.info("Received termination pill for app %s", app_id)
-        os.kill(self.active_minions[app_id].pid, signal.SIGTERM)
-        del self.active_minions[app_id]
+        assert (workflow_id,app_id) in self.active_minions
+        log.info("Terminating (workflow_id=%s,app_id=%s)", \
+                workflow_id, app_id)
+        os.kill(self.active_minions[(workflow_id,app_id)].pid, signal.SIGTERM)
+        del self.active_minions[(workflow_id,app_id)]
 
     def minion_support(self):
         parsed_url = urlparse.urlparse(
@@ -201,6 +212,7 @@ class JuicerServer:
     def watch_minion_status(self):
         parsed_url = urlparse.urlparse(
             self.config['juicer']['servers']['redis_url'])
+        log.info('%s', parsed_url)
         redis_conn = redis.StrictRedis(host=parsed_url.hostname,
                                        port=parsed_url.port)
         JuicerServer.watch_minion_process(redis_conn)
@@ -210,10 +222,12 @@ class JuicerServer:
         pubsub = redis_conn.pubsub()
         pubsub.psubscribe('__keyevent@*__:expired')
         for msg in pubsub.listen():
+            log.info('watch subscribe: %s', msg)
             if msg.get('type') == 'pmessage' and 'minion' in msg.get('data'):
                 log.warn('Minion {id} stopped'.format(id=msg.get('data')))
 
     def process(self):
+        log.info('Juicer server started (pid=%s)', os.getpid())
         self.start_process = multiprocessing.Process(
             name="master", target=self.start)
         self.start_process.daemon = False
@@ -222,12 +236,17 @@ class JuicerServer:
             name="help_desk", target=self.minion_support)
         self.minion_support_process.daemon = False
 
-        self.minion_status_process = multiprocessing.Process(
+        self.minion_watch_process = multiprocessing.Process(
             name="minion_status", target=self.watch_minion_status)
-        self.minion_status_process.daemon = False
+        self.minion_watch_process.daemon = False
 
         self.start_process.start()
         self.minion_support_process.start()
+        self.minion_watch_process.start()
+        
+        self.start_process.join()
+        self.minion_support_process.join()
+        self.minion_watch_process.join()
 
 
 if __name__ == '__main__':
@@ -243,7 +262,6 @@ if __name__ == '__main__':
     minion_executable = os.path.abspath(
             os.path.join(os.path.dirname(__file__), 'minion.py'))
 
-    log.info('Starting Juicer Server')
     server = JuicerServer(juicer_config, minion_executable,
             config_file_path=args.config)
     server.process()

--- a/juicer/runner/minion.py
+++ b/juicer/runner/minion.py
@@ -9,9 +9,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-c", "--config", help="Config file", required=True)
-    parser.add_argument("-w", "--worflow_id", help="Workflow id", type=int,
+    parser.add_argument("-w", "--worflow_id", help="Workflow id", type=str,
                         required=True)
-    parser.add_argument("-a", "--app_id", help="Job id", type=int,
+    parser.add_argument("-a", "--app_id", help="Job id", type=str,
                         required=True)
     parser.add_argument("-t", "--type", help="Execution engine",
                         required=False, default="SPARK")

--- a/juicer/runner/minion.py
+++ b/juicer/runner/minion.py
@@ -9,6 +9,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-c", "--config", help="Config file", required=True)
+    parser.add_argument("-w", "--worflow_id", help="Workflow id", type=int,
+                        required=True)
     parser.add_argument("-a", "--app_id", help="Job id", type=int,
                         required=True)
     parser.add_argument("-t", "--type", help="Execution engine",
@@ -24,7 +26,8 @@ if __name__ == '__main__':
                                    port=parsed_url.port)
     if args.type == 'SPARK':
         # log.info('Starting Juicer Spark Minion')
-        server = SparkMinion(redis_conn, args.app_id, juicer_config)
+        server = SparkMinion(redis_conn,
+                args.worflow_id, args.app_id, juicer_config)
         server.process()
     else:
         raise ValueError(

--- a/juicer/runner/minion.py
+++ b/juicer/runner/minion.py
@@ -9,9 +9,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-c", "--config", help="Config file", required=True)
-    parser.add_argument("-j", "--job_id", help="Job id", type=int,
+    parser.add_argument("-a", "--app_id", help="Job id", type=int,
                         required=True)
-    parser.add_argument("-t", "--type", help="Processing technology type",
+    parser.add_argument("-t", "--type", help="Execution engine",
                         required=False, default="SPARK")
     args = parser.parse_args()
 
@@ -24,7 +24,7 @@ if __name__ == '__main__':
                                    port=parsed_url.port)
     if args.type == 'SPARK':
         # log.info('Starting Juicer Spark Minion')
-        server = SparkMinion(redis_conn, args.job_id, juicer_config)
+        server = SparkMinion(redis_conn, args.app_id, juicer_config)
         server.process()
     else:
         raise ValueError(

--- a/juicer/runner/minion_base.py
+++ b/juicer/runner/minion_base.py
@@ -2,10 +2,10 @@ from juicer.runner.control import StateControlRedis
 
 
 class Minion:
-    def __init__(self, redis_conn, job_id, config):
+    def __init__(self, redis_conn, app_id, config):
         self.redis_conn = redis_conn
         self.state_control = StateControlRedis(self.redis_conn)
-        self.job_id = job_id
+        self.app_id = app_id
         self.config = config
 
     def process(self):

--- a/juicer/runner/minion_base.py
+++ b/juicer/runner/minion_base.py
@@ -2,9 +2,10 @@ from juicer.runner.control import StateControlRedis
 
 
 class Minion:
-    def __init__(self, redis_conn, app_id, config):
+    def __init__(self, redis_conn, workflow_id, app_id, config):
         self.redis_conn = redis_conn
         self.state_control = StateControlRedis(self.redis_conn)
+        self.workflow_id = workflow_id
         self.app_id = app_id
         self.config = config
 

--- a/juicer/spark/data_operation.py
+++ b/juicer/spark/data_operation.py
@@ -200,7 +200,7 @@ class Save(Operation):
             'http://beta.ctweb.inweb.org.br/limonero', '123456',
             self.storage_id)
 
-        final_url = '{}{}{}'.format(storage['url'], self.path,
+        final_url = '{}/{}/{}'.format(storage['url'], self.path,
                                     self.name.replace(' ', '_'))
         code_save = ''
         if self.format == self.FORMAT_CSV:

--- a/juicer/spark/operation.tmpl
+++ b/juicer/spark/operation.tmpl
@@ -18,12 +18,12 @@ from timeit import default_timer as timer
 from pyspark.ml import classification, evaluation, feature, tuning, clustering
 from pyspark.sql import functions, types
 
-# from pyspark.ml import Pipeline
-# from pyspark.ml.classification import *
-# from pyspark.ml.clustering import *
-# from pyspark.ml.evaluation import *
-# from pyspark.ml.feature import *
-# from pyspark.ml.tuning import *
+from pyspark.ml import Pipeline
+from pyspark.ml.classification import *
+from pyspark.ml.clustering import *
+from pyspark.ml.evaluation import *
+from pyspark.ml.feature import *
+from pyspark.ml.tuning import *
 # from pyspark.sql import SparkSession
 # from pyspark.sql.functions import *
 # from pyspark.sql.types import *

--- a/juicer/spark/operation.tmpl
+++ b/juicer/spark/operation.tmpl
@@ -15,48 +15,58 @@ import unicodedata
 
 from timeit import default_timer as timer
 
-from pyspark.ml import classification, evaluation, feature, tuning, clustering
+# from pyspark.ml import classification, evaluation, feature, tuning, clustering
 from pyspark.sql import functions, types
 
-from pyspark.ml import Pipeline
+# from pyspark.ml import Pipeline
 # from pyspark.ml.classification import *
 # from pyspark.ml.clustering import *
 # from pyspark.ml.evaluation import *
 # from pyspark.ml.feature import *
 # from pyspark.ml.tuning import *
-from pyspark.sql import SparkSession
+# from pyspark.sql import SparkSession
 # from pyspark.sql.functions import *
 # from pyspark.sql.types import *
 
+# We need the following code in order to integrate this application log with the
+# spark standard log4j. Thus, we set *__SPARK_LOG__* at most one time per execution.
+__SPARK_LOG__ = None
+def sparkLogging(spark_session):
+    global __SPARK_LOG__
+    if not __SPARK_LOG__:
+       log4jLogger = spark_session.sparkContext._jvm.org.apache.log4j
+       __SPARK_LOG__ = log4jLogger.LogManager.getLogger(__name__)
+    return __SPARK_LOG__
 
 
 reload(sys)
 sys.setdefaultencoding('utf8')
 
 # Global utilities functions definitions
-strip_accents = functions.udf(
-    lambda text: ''.join(c for c in unicodedata.normalize('NFD', text)
-                         if unicodedata.category(c) != 'Mn'),
-    types.StringType())
-strip_punctuation = functions.udf(lambda text:
-                                  text.translate(
-                                      dict((ord(char), None)
-                                           for char in string.punctuation)),
-                                  types.StringType())
+# strip_accents = functions.udf(
+#     lambda text: ''.join(c for c in unicodedata.normalize('NFD', text)
+#                          if unicodedata.category(c) != 'Mn'),
+#     types.StringType())
+# strip_punctuation = functions.udf(lambda text:
+#                                   text.translate(
+#                                       dict((ord(char), None)
+#                                            for char in string.punctuation)),
+#                                   types.StringType())
 
-def juicer_debug(name, variable, data_frame):
+def juicer_debug(spark_session, name, variable, data_frame):
     """ Debug code """
-    print '#' * 20
-    print '|| {} ||'.format(name)
-    print '== {} =='.format(variable)
+    sparkLogging(spark_session).debug('#' * 20)
+    sparkLogging(spark_session).debug('|| {} ||'.format(name))
+    sparkLogging(spark_session).debug('== {} =='.format(variable))
     data_frame.show()
     schema = data_frame.schema
     for attr in schema:
-        print attr.name, attr.dataType, attr.nullable, attr.metadata
+        sparkLogging(spark_session).debug('{} {} {} {}'.format(attr.name, attr.dataType, attr.nullable, attr.metadata))
 {% autopep8 %}
 {%- for instance in instances %}
 {%- if instance.has_code %}
-def {{instance.parameters.task.operation.slug.replace('-', '_')}}_gen_{{instance.get_output_names('_')}}(spark_session
+def {{instance.parameters.task.operation.slug.replace('-', '_')}}_gen_{{instance.get_output_names('_')}}(
+        spark_session, cached_state
         {%- if instance.get_inputs_names %}, {{instance.get_inputs_names}}{% endif %}):
     {%- if instance.parameters.task.forms.comment and instance.parameters.task.forms.comment.value.strip()%}
     """
@@ -65,13 +75,18 @@ def {{instance.parameters.task.operation.slug.replace('-', '_')}}_gen_{{instance
     {%- else %}
     """ Operation {{instance.parameters.task.id }} """
     {%- endif %}
+
+    if '{{instance.parameters.task.id}}' in cached_state:
+        sparkLogging(spark_session).info ('Cache hit for operation {}'.format('{{instance.parameters.task.id}}'))
+        return cached_state.get('{{instance.parameters.task.id}}')
+
     start = timer()
     {{instance.generate_code().strip() | indent(width=4, indentfirst=False)}}
     {%- if instance.parameters.get('logging', {}).get('log_level') == 'DEBUG' %}
     {%- set out = instance.get_data_out_names('|') %}
     {%- if out %}
     {%- for variable in out.split('|')%}
-    juicer_debug('{{instance.__class__}}', '{{variable}}', {{variable}})
+    juicer_debug(spark_session, '{{instance.__class__}}', '{{variable}}', {{variable}})
     {%- endfor %}
     {%- endif %}
     {%- endif %}
@@ -82,21 +97,17 @@ def {{instance.parameters.task.operation.slug.replace('-', '_')}}_gen_{{instance
 {%- endif %}
 {% endfor %}
 
-def main():
+def main(spark_session, cached_state):
     """ Run generated code """
+
     start = time.time()
-    app_name = u'## {{workflow_name}} ##'
 
-    spark_options = {
-        "driver-library-path": '{}/lib/native/'.format(
-            os.environ.get('HADOOP_HOME')),
+    spark_session.sparkContext.setLogLevel ('INFO')
+    print 'appName', spark_session.sparkContext.appName
+    print 'session', spark_session
 
-    }
-    builder = SparkSession.builder.appName(app_name)
-
-    spark_session = builder.getOrCreate()
-    for option, value in spark_options.iteritems():
-        spark_session.conf.set(option, value)
+    test_rdd = spark_session.sparkContext.parallelize (range(1, 1000000))
+    print test_rdd.count() 
 
     session_start_time = time.time()
     # spark_session.sparkContext.addPyFile('/tmp/dist.zip')
@@ -118,7 +129,7 @@ def main():
     {%- if instance.has_code and is_satisfied %}
     {%- set s = dependency_controller.satisfied(instance.parameters.task.id) %}
     {%- if is_satisfied %}
-    {% if instance.get_output_names(", ") %}{{instance.get_output_names(", ")}}, {% endif %}ts_{{instance.output}} = {{instance.parameters.task.operation.slug.replace('-', '_')}}_gen_{{instance.get_output_names('_')}}(spark_session
+    {% if instance.get_output_names(", ") %}{{instance.get_output_names(", ")}}, {% endif %}ts_{{instance.output}} = {{instance.parameters.task.operation.slug.replace('-', '_')}}_gen_{{instance.get_output_names('_')}}(spark_session, cached_state
         {%- if instance.get_inputs_names %}, {{instance.get_inputs_names}}{% endif %})
     {%- endif %}
     {%- else %}

--- a/juicer/spark/operation.tmpl
+++ b/juicer/spark/operation.tmpl
@@ -15,7 +15,7 @@ import unicodedata
 
 from timeit import default_timer as timer
 
-# from pyspark.ml import classification, evaluation, feature, tuning, clustering
+from pyspark.ml import classification, evaluation, feature, tuning, clustering
 from pyspark.sql import functions, types
 
 # from pyspark.ml import Pipeline
@@ -41,17 +41,6 @@ def sparkLogging(spark_session):
 
 reload(sys)
 sys.setdefaultencoding('utf8')
-
-# Global utilities functions definitions
-# strip_accents = functions.udf(
-#     lambda text: ''.join(c for c in unicodedata.normalize('NFD', text)
-#                          if unicodedata.category(c) != 'Mn'),
-#     types.StringType())
-# strip_punctuation = functions.udf(lambda text:
-#                                   text.translate(
-#                                       dict((ord(char), None)
-#                                            for char in string.punctuation)),
-#                                   types.StringType())
 
 def juicer_debug(spark_session, name, variable, data_frame):
     """ Debug code """
@@ -102,13 +91,6 @@ def main(spark_session, cached_state):
 
     start = time.time()
 
-    spark_session.sparkContext.setLogLevel ('INFO')
-    print 'appName', spark_session.sparkContext.appName
-    print 'session', spark_session
-
-    test_rdd = spark_session.sparkContext.parallelize (range(1, 1000000))
-    print test_rdd.count() 
-
     session_start_time = time.time()
     # spark_session.sparkContext.addPyFile('/tmp/dist.zip')
 
@@ -136,6 +118,7 @@ def main(spark_session, cached_state):
     # Task **{{instance.parameters.task.operation.name}}** did not genarate code
     {%- endif %}
     {%- endfor %}
+
 
     end = time.time()
     print "{}\t{}".format(end - start, end - session_start_time)

--- a/juicer/spark/spark_minion.py
+++ b/juicer/spark/spark_minion.py
@@ -58,7 +58,7 @@ class SparkMinion(Minion):
 
         self.job_count = 0
         self.spark_session = None
-        signal.signal(signal.SIGTERM, self.terminate)
+        signal.signal(signal.SIGTERM, self._terminate)
 
     def get_and_inc_job_count(self):
         ccount = self.job_count
@@ -107,7 +107,8 @@ class SparkMinion(Minion):
             workflow = app_info.get('workflow')
 
             loader = Workflow(workflow)
-            module_name = 'juicer_app_{}_{}'.format(
+            module_name = 'juicer_app_{}_{}_{}'.format(
+		    self.workflow_id,
                     self.app_id,
                     self.get_and_inc_job_count())
 
@@ -283,7 +284,7 @@ class SparkMinion(Minion):
                     'message': self.MNN004[1]}
             self._send_to_output(data)
 
-    def terminate(self, _signal, _frame):
+    def _terminate(self, _signal, _frame):
         self.terminate()
     
     def terminate(self):
@@ -296,6 +297,7 @@ class SparkMinion(Minion):
         log.info('Closing spark session and terminating subprocesses')
         if self.spark_session:
             self.spark_session.stop()
+	    self.spark_session = None
         if self.execute_process:
             os.kill(self.execute_process.pid, signal.SIGKILL)
         if self.ping_process:

--- a/tests/runner/fixtures/juicer-server-config.yaml
+++ b/tests/runner/fixtures/juicer-server-config.yaml
@@ -1,0 +1,3 @@
+juicer:
+   servers:
+      redis_url: http://127.0.0.1:6379

--- a/tests/runner/test_juicer_server.py
+++ b/tests/runner/test_juicer_server.py
@@ -25,7 +25,12 @@ def test_runner_read_start_queue_success():
     }
     app_id = '1'
     workflow_id = '1000'
-    workflow = {"app_id": app_id, 'workflow_id': workflow_id}
+    workflow = {
+        'workflow_id': workflow_id,
+        'app_id': app_id,
+        'type': 'execute',
+        'workflow': ''
+    }
 
     with mock.patch('redis.StrictRedis',
                     mock_strict_redis_client) as mocked_redis:
@@ -58,7 +63,7 @@ def test_runner_read_start_queue_success():
             assert state_control.get_workflow_status(
                 workflow_id) == JuicerServer.STARTED
             assert json.loads(state_control.pop_app_output_queue(app_id)) == {
-                'code': 0, 'message': 'Workflow will start soon'}
+                'code': 0, 'message': 'Minion is processing message execute'}
 
 
 def test_runner_read_start_queue_workflow_not_started_failure():
@@ -71,7 +76,12 @@ def test_runner_read_start_queue_workflow_not_started_failure():
     }
     app_id = '1'
     workflow_id = '1000'
-    workflow = {"app_id": app_id, 'workflow_id': workflow_id}
+    workflow = {
+        'workflow_id': workflow_id,
+        'app_id': app_id,
+        'type': 'execute',
+        'workflow': ''
+    }
 
     with mock.patch('redis.StrictRedis',
                     mock_strict_redis_client) as mocked_redis:
@@ -85,7 +95,7 @@ def test_runner_read_start_queue_workflow_not_started_failure():
 
             # This workflow is being processed, should not start it again
             # state_control.set_workflow_status(workflow_id, JuicerServer.STARTED)
-            server.active_minions[app_id] = '_'
+            server.active_minions[(workflow_id, app_id)] = '_'
 
             # Start of testing
             server.read_start_queue(mocked_redis_conn)
@@ -114,7 +124,12 @@ def test_runner_read_start_queue_minion_already_running_success():
     }
     app_id = 1
     workflow_id = 1000
-    workflow = {"app_id": app_id, 'workflow_id': workflow_id}
+    workflow = {
+        'workflow_id': workflow_id,
+        'app_id': app_id,
+        'type': 'execute',
+        'workflow': ''
+    }
 
     with mock.patch('redis.StrictRedis',
                     mock_strict_redis_client) as mocked_redis:
@@ -141,7 +156,7 @@ def test_runner_read_start_queue_minion_already_running_success():
             assert state_control.get_workflow_status(
                 workflow_id) == JuicerServer.STARTED
             assert json.loads(state_control.pop_app_output_queue(app_id)) == {
-                'code': 0, 'message': 'Workflow will start soon'}
+                'code': 0, 'message': 'Minion is processing message execute'}
 
 
 def test_runner_read_start_queue_missing_details_failure():
@@ -155,7 +170,12 @@ def test_runner_read_start_queue_missing_details_failure():
     app_id = 1
     workflow_id = 1000
     # incorrect key, should raise exception
-    workflow = {"xapp_id": app_id, 'workflow_id': workflow_id}
+    workflow = {
+        'workflow_id': workflow_id,
+        'xapp_id': app_id,
+        'type': 'execute',
+        'workflow': ''
+    }
 
     with mock.patch('redis.StrictRedis',
                     mock_strict_redis_client) as mocked_redis:
@@ -300,7 +320,12 @@ def test_runner_multiple_jobs_single_app():
     }
     app_id = 1
     workflow_id = 1000
-    workflow = {"app_id": app_id, 'workflow_id': workflow_id}
+    workflow = {
+        'workflow_id': workflow_id,
+        'app_id': app_id,
+        'type': 'execute',
+        'workflow': ''
+    }
 
     with mock.patch('redis.StrictRedis',
             mock_strict_redis_client) as mocked_redis:
@@ -338,10 +363,21 @@ def test_runner_multiple_jobs_multiple_apps():
             }
         }
     }
+
     app_id = 1
     workflow_id = 1000
-    workflow1 = {"app_id": app_id, 'workflow_id': workflow_id}
-    workflow2 = {"app_id": app_id + 1, 'workflow_id': workflow_id + 1}
+    workflow1 = {
+        'workflow_id': workflow_id,
+        'app_id': app_id,
+        'type': 'execute',
+        'workflow': ''
+    }
+    workflow2 = {
+        'workflow_id': workflow_id + 1,
+        'app_id': app_id + 1,
+        'type': 'execute',
+        'workflow': ''
+    }
 
     with mock.patch('redis.StrictRedis',
             mock_strict_redis_client) as mocked_redis:
@@ -391,12 +427,31 @@ def test_runner_minion_termination():
     }
     app_id = 1
     workflow_id = 1000
-    workflow1 = {"app_id": app_id, 'workflow_id': workflow_id}
-    workflow1_kill = {"app_id": app_id, 'workflow_id': workflow_id,
-            "terminate": "true"}
-    workflow2 = {"app_id": app_id + 1, 'workflow_id': workflow_id + 1}
-    workflow2_kill = {"app_id": app_id + 1, 'workflow_id': workflow_id + 1,
-            "terminate": "true"}
+    workflow1 = {
+        'workflow_id': workflow_id,
+        'app_id': app_id,
+        'type': 'execute',
+        'workflow': ''
+    }
+    
+    workflow1_kill = {
+        'workflow_id': workflow_id,
+        'app_id': app_id,
+        'type': 'terminate'
+    }
+
+    workflow2 = {
+        'workflow_id': workflow_id + 1,
+        'app_id': app_id + 1,
+        'type': 'execute',
+        'workflow': ''
+    }
+    
+    workflow2_kill = {
+        'workflow_id': workflow_id + 1,
+        'app_id': app_id + 1,
+        'type': 'terminate'
+    }
 
     with mock.patch('redis.StrictRedis',
             mock_strict_redis_client) as mocked_redis:

--- a/tests/spark/test_spark_minion.py
+++ b/tests/spark/test_spark_minion.py
@@ -93,13 +93,15 @@ class DataFrame:
 
 # noinspection PyProtectedMember
 def test_minion_ping_success():
+    workflow_id = 6666
     app_id = 897987
 
     with mock.patch('redis.StrictRedis',
                     mock_strict_redis_client) as mocked_redis:
         redis_conn = mocked_redis()
-        minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                             config=config)
+        minion = SparkMinion(redis_conn=redis_conn,
+                workflow_id=workflow_id, app_id=app_id,
+                config=config)
         minion._perform_ping()
 
         state_control = StateControlRedis(redis_conn)
@@ -111,13 +113,15 @@ def test_minion_ping_success():
 
 # noinspection PyProtectedMember
 def test_minion_generate_output_success():
+    workflow_id = 6666
     app_id = 897987
 
     with mock.patch('redis.StrictRedis',
                     mock_strict_redis_client) as mocked_redis:
         redis_conn = mocked_redis()
-        minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                             config=config)
+        minion = SparkMinion(redis_conn=redis_conn,
+                workflow_id=workflow_id, app_id=app_id,
+                config=config)
 
         state_control = StateControlRedis(redis_conn)
 
@@ -127,7 +131,7 @@ def test_minion_generate_output_success():
             result = json.loads(
                 state_control.pop_app_output_queue(app_id, False))
             assert sorted(result.keys()) == sorted(
-                ['date', 'status', 'message', 'app_id', 'code'])
+                ['date', 'status', 'message', 'workflow_id', 'app_id', 'code'])
             assert result['app_id'] == app_id
             assert result['message'] == msg
         assert state_control.get_app_output_queue_size(app_id) == 0
@@ -135,6 +139,7 @@ def test_minion_generate_output_success():
 
 # noinspection PyProtectedMember
 def test_minion_perform_execute_success():
+    workflow_id = 6666
     app_id = 897447
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
 
@@ -145,8 +150,9 @@ def test_minion_perform_execute_success():
             mocked_transpile.side_effect = get_side_effect(None, 0, 1)
 
             redis_conn = mocked_redis()
-            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                                 config=config)
+            minion = SparkMinion(redis_conn=redis_conn,
+                    workflow_id=workflow_id, app_id=app_id,
+                    config=config)
 
             # Configure mocked redis
             state_control = StateControlRedis(redis_conn)
@@ -166,6 +172,7 @@ def test_minion_perform_execute_success():
 
 # noinspection PyProtectedMember
 def test_minion_perform_execute_reload_code_success():
+    workflow_id = 6666
     app_id = 667788
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
 
@@ -176,8 +183,9 @@ def test_minion_perform_execute_reload_code_success():
             mocked_transpile.side_effect = get_side_effect(None, None, 2)
 
             redis_conn = mocked_redis()
-            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                                 config=config)
+            minion = SparkMinion(redis_conn=redis_conn,
+                    workflow_id=workflow_id, app_id=app_id,
+                    config=config)
 
             # Configure mocked redis
             state_control = StateControlRedis(redis_conn)
@@ -206,6 +214,7 @@ def test_minion_perform_execute_reload_code_success():
 
 # noinspection PyProtectedMember
 def test_minion_generate_invalid_code_failure():
+    workflow_id = 6666
     app_id = 666
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
 
@@ -215,8 +224,9 @@ def test_minion_generate_invalid_code_failure():
             # Setup for mocked_transpile
             mocked_transpile.side_effect = get_side_effect(None, None, 4)
             redis_conn = mocked_redis()
-            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                                 config=config)
+            minion = SparkMinion(redis_conn=redis_conn,
+                    workflow_id=workflow_id, app_id=app_id,
+                    config=config)
             # Configure mocked redis
             with open(os.path.join(os.path.dirname(__file__),
                                    'fixtures/simple_workflow.json')) as f:
@@ -237,6 +247,7 @@ def test_minion_generate_invalid_code_failure():
 
 # noinspection PyProtectedMember
 def test_minion_perform_deliver_success():
+    workflow_id = 6666
     app_id = 1000
     out_queue = 'queue_2000'
     sconf = SparkConf()
@@ -256,8 +267,9 @@ def test_minion_perform_deliver_success():
             'output': out_queue
         }
         state_control.push_app_delivery_queue(app_id, json.dumps(data))
-        minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                             config=config)
+        minion = SparkMinion(redis_conn=redis_conn,
+                workflow_id=workflow_id, app_id=app_id,
+                config=config)
         minion.state = {
             data['task_id']: (df0, 35.92)
         }
@@ -276,6 +288,7 @@ def test_minion_perform_deliver_success():
 
 # noinspection PyProtectedMember
 def test_minion_perform_deliver_missing_state_process_app_with_success():
+    workflow_id = 6666
     app_id = 1000
     out_queue = 'queue_2000'
     task_id = '033f-284ab-28987e'
@@ -298,8 +311,9 @@ def test_minion_perform_deliver_missing_state_process_app_with_success():
             }
 
             state_control.push_app_delivery_queue(app_id, json.dumps(data))
-            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                                 config=config)
+            minion = SparkMinion(redis_conn=redis_conn,
+                    workflow_id=workflow_id, app_id=app_id,
+                    config=config)
             minion.state = {
             }
             minion._perform_deliver()
@@ -317,6 +331,7 @@ def test_minion_perform_deliver_missing_state_process_app_with_success():
 
 # noinspection PyProtectedMember
 def test_minion_perform_deliver_missing_state_process_app_with_failure():
+    workflow_id = 6666
     app_id = 6000
     out_queue = 'queue_2000'
     task_id = '033f-284ab-28987e'
@@ -340,8 +355,9 @@ def test_minion_perform_deliver_missing_state_process_app_with_failure():
             }
 
             state_control.push_app_delivery_queue(app_id, json.dumps(data))
-            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                                 config=config)
+            minion = SparkMinion(redis_conn=redis_conn,
+                    workflow_id=workflow_id, app_id=app_id,
+                    config=config)
             minion.state = {
             }
             minion._perform_deliver()
@@ -379,6 +395,7 @@ def test_minion_perform_deliver_missing_state_process_app_with_failure():
 
 # noinspection PyProtectedMember
 def test_minion_perform_deliver_missing_state_invalid_port_failure():
+    workflow_id = 6666
     app_id = 5001
     out_queue = 'queue_50001'
     task_id = 'f033f-284ab-28987e-232add'
@@ -401,8 +418,9 @@ def test_minion_perform_deliver_missing_state_invalid_port_failure():
             }
 
             state_control.push_app_delivery_queue(app_id, json.dumps(data))
-            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                                 config=config)
+            minion = SparkMinion(redis_conn=redis_conn,
+                    workflow_id=workflow_id, app_id=app_id,
+                    config=config)
             minion.state = {}
             minion._perform_deliver()
 
@@ -424,6 +442,7 @@ def test_minion_perform_deliver_missing_state_invalid_port_failure():
 
 # noinspection PyProtectedMember
 def test_minion_perform_deliver_missing_state_unsupported_output_failure():
+    workflow_id = 6666
     app_id = 4001
     out_queue = 'queue_40001'
     task_id = 'f033f-284ab-28987e-232add'
@@ -446,8 +465,9 @@ def test_minion_perform_deliver_missing_state_unsupported_output_failure():
             }
 
             state_control.push_app_delivery_queue(app_id, json.dumps(data))
-            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
-                                 config=config)
+            minion = SparkMinion(redis_conn=redis_conn,
+                    workflow_id=workflow_id, app_id=app_id,
+                    config=config)
             minion.state = {
             }
             minion._perform_deliver()
@@ -467,22 +487,68 @@ def test_minion_perform_deliver_missing_state_unsupported_output_failure():
             result = state_control.pop_queue(out_queue, False)
             assert result is None, 'Wrong CSV generated'
 
-def test_terminate_minion():
-    """ TODO
-    - Start a juicer server
-    - Instanciate two minions
-    - Kill the first, assert that it was killed and the other remains
-    - Kill the second, assert that all minions were killed and their state
-      cleaned
+def test_runner_minion_spark_configuration():
     """
-    assert True
-
-def test_minion_spark_configuration():
-    """ TODO
     - Start a juicer server
     - Instanciate one minion passing specific configurations w.r.t. runtime
       environments (app_configs)
     - Assert that the spark context within the minion inherited the same configs
       that it was supposed to inherit
     """
-    assert True
+    
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError as ie:
+        # we will skip this test because pyspark is not installed
+        return
+
+    workflow_id = '6666'
+    app_id = '897447'
+    app_configs = {'spark.master': 'local[3]',
+            'config1': '1', 'config2': '2'}
+    function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
+
+    with mock.patch('redis.StrictRedis',
+                    mock_strict_redis_client) as mocked_redis:
+        with mock.patch(function_name) as mocked_transpile:
+            # Setup for mocked_transpile
+            mocked_transpile.side_effect = get_side_effect(None, 0, 1)
+
+            redis_conn = mocked_redis()
+            minion = SparkMinion(redis_conn=redis_conn,
+                    workflow_id=workflow_id, app_id=app_id,
+                    config=config)
+
+            # Configure mocked redis
+            state_control = StateControlRedis(redis_conn)
+            with open(os.path.join(os.path.dirname(__file__),
+                                   'fixtures/simple_workflow.json')) as f:
+                data = json.loads(f.read())
+
+            state_control.push_app_queue(app_id, json.dumps({
+                'workflow_id': workflow_id,
+                'app_id': app_id,
+                'app_configs': app_configs,
+                'workflow': data
+                }))
+
+            minion._perform_execute()
+
+            # check spark session health
+            assert not minion.spark_session is None
+            assert minion.is_spark_session_available()
+
+            # check configs
+            ctx_configs = minion.spark_session.sparkContext.getConf().getAll()
+            ctx_configs = {k:v for k,v in ctx_configs}
+            for k,v in app_configs.iteritems():
+                assert ctx_configs[k] == v
+
+            # check app name
+            assert minion.spark_session.sparkContext.appName == \
+                    data['name']
+
+            # check proper termination
+            minion.terminate()
+            assert not minion.is_spark_session_available()
+

--- a/tests/spark/test_spark_minion.py
+++ b/tests/spark/test_spark_minion.py
@@ -47,7 +47,7 @@ def get_side_effect(records, task_id, index=0):
 
                 def take(self, total):
                     return self
-            def main():
+            def main(spark_session, cached_data):
                 return {{
                     '{task_id}': (DataFrame(rdd), 20.0)
                 }}
@@ -56,7 +56,7 @@ def get_side_effect(records, task_id, index=0):
     # noinspection PyUnusedLocal
     def side_effect1(w, g, c, out):
         print(dedent("""
-            def main():
+            def main(spark_session, cached_data):
                 return {
                     "xyz-647": ("df", 27.27)
                 }"""), file=out)
@@ -64,18 +64,18 @@ def get_side_effect(records, task_id, index=0):
     # noinspection PyUnusedLocal
     def side_effect2(w, g, c, out):
         print(dedent("""
-            def main():
+            def main(spark_session, cached_data):
                 return 'version 1.0' """), file=out)
 
     def side_effect3(w, g, c, out):
         print(dedent("""
-            def main():
+            def main(spark_session, cached_data):
                 return 'version 2.1' """), file=out)
 
     # noinspection PyUnusedLocal
     def side_effect4(w, g, c, out):
         print(dedent("""
-            def main():
+            def main(spark_session, cached_data):
                 return Invalid Code """), file=out)
 
     return \
@@ -93,30 +93,30 @@ class DataFrame:
 
 # noinspection PyProtectedMember
 def test_minion_ping_success():
-    job_id = 897987
+    app_id = 897987
 
     with mock.patch('redis.StrictRedis',
                     mock_strict_redis_client) as mocked_redis:
         redis_conn = mocked_redis()
-        minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+        minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                              config=config)
         minion._perform_ping()
 
         state_control = StateControlRedis(redis_conn)
 
-        assert json.loads(state_control.get_minion_status(job_id)) == {
+        assert json.loads(state_control.get_minion_status(app_id)) == {
             'status': 'READY', 'pid': os.getpid()}
-        assert state_control.get_job_output_queue_size(job_id) == 0
+        assert state_control.get_app_output_queue_size(app_id) == 0
 
 
 # noinspection PyProtectedMember
 def test_minion_generate_output_success():
-    job_id = 897987
+    app_id = 897987
 
     with mock.patch('redis.StrictRedis',
                     mock_strict_redis_client) as mocked_redis:
         redis_conn = mocked_redis()
-        minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+        minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                              config=config)
 
         state_control = StateControlRedis(redis_conn)
@@ -125,17 +125,17 @@ def test_minion_generate_output_success():
         for msg in msgs:
             minion._generate_output(msg)
             result = json.loads(
-                state_control.pop_job_output_queue(job_id, False))
+                state_control.pop_app_output_queue(app_id, False))
             assert sorted(result.keys()) == sorted(
-                ['date', 'status', 'message', 'job_id', 'code'])
-            assert result['job_id'] == job_id
+                ['date', 'status', 'message', 'app_id', 'code'])
+            assert result['app_id'] == app_id
             assert result['message'] == msg
-        assert state_control.get_job_output_queue_size(job_id) == 0
+        assert state_control.get_app_output_queue_size(app_id) == 0
 
 
 # noinspection PyProtectedMember
 def test_minion_perform_execute_success():
-    job_id = 897447
+    app_id = 897447
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
 
     with mock.patch('redis.StrictRedis',
@@ -145,7 +145,7 @@ def test_minion_perform_execute_success():
             mocked_transpile.side_effect = get_side_effect(None, 0, 1)
 
             redis_conn = mocked_redis()
-            minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                                  config=config)
 
             # Configure mocked redis
@@ -154,19 +154,19 @@ def test_minion_perform_execute_success():
                                    'fixtures/simple_workflow.json')) as f:
                 data = json.loads(f.read())
 
-            state_control.push_job_queue(job_id, json.dumps({'workflow': data}))
+            state_control.push_app_queue(app_id, json.dumps({'workflow': data}))
 
             minion._perform_execute()
 
             assert minion.state == {"xyz-647": ("df", 27.27)}, 'Invalid state'
 
-            assert state_control.get_job_output_queue_size(
-                job_id) == 1, 'Wrong number of output messages'
+            assert state_control.get_app_output_queue_size(
+                app_id) == 1, 'Wrong number of output messages'
 
 
 # noinspection PyProtectedMember
 def test_minion_perform_execute_reload_code_success():
-    job_id = 667788
+    app_id = 667788
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
 
     with mock.patch('redis.StrictRedis',
@@ -176,7 +176,7 @@ def test_minion_perform_execute_reload_code_success():
             mocked_transpile.side_effect = get_side_effect(None, None, 2)
 
             redis_conn = mocked_redis()
-            minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                                  config=config)
 
             # Configure mocked redis
@@ -185,28 +185,28 @@ def test_minion_perform_execute_reload_code_success():
                                    'fixtures/simple_workflow.json')) as f:
                 data = json.loads(f.read())
 
-            state_control.push_job_queue(job_id, json.dumps({'workflow': data}))
+            state_control.push_app_queue(app_id, json.dumps({'workflow': data}))
 
             minion._perform_execute()
             assert minion.state == 'version 1.0', 'Invalid state'
 
             # Executes the same workflow, but code should be different
-            state_control.push_job_queue(job_id, json.dumps({'workflow': data}))
-            assert state_control.get_job_output_queue_size(
-                job_id) == 1, 'Wrong number of output messages'
+            state_control.push_app_queue(app_id, json.dumps({'workflow': data}))
+            assert state_control.get_app_output_queue_size(
+                app_id) == 1, 'Wrong number of output messages'
 
             minion.transpiler.transpile = get_side_effect(None, None, 3)
             minion._perform_execute()
 
             assert minion.state == 'version 2.1', 'Invalid state'
 
-            assert state_control.get_job_output_queue_size(
-                job_id) == 2, 'Wrong number of output messages'
+            assert state_control.get_app_output_queue_size(
+                app_id) == 2, 'Wrong number of output messages'
 
 
 # noinspection PyProtectedMember
 def test_minion_generate_invalid_code_failure():
-    job_id = 666
+    app_id = 666
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
 
     with mock.patch('redis.StrictRedis',
@@ -215,29 +215,29 @@ def test_minion_generate_invalid_code_failure():
             # Setup for mocked_transpile
             mocked_transpile.side_effect = get_side_effect(None, None, 4)
             redis_conn = mocked_redis()
-            minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                                  config=config)
             # Configure mocked redis
             with open(os.path.join(os.path.dirname(__file__),
                                    'fixtures/simple_workflow.json')) as f:
                 data = json.loads(f.read())
             state_control = StateControlRedis(redis_conn)
-            state_control.push_job_queue(job_id, json.dumps({'workflow': data}))
+            state_control.push_app_queue(app_id, json.dumps({'workflow': data}))
             minion._perform_execute()
 
-            assert state_control.get_job_output_queue_size(
-                job_id) == 2, 'Wrong number of output messages'
+            assert state_control.get_app_output_queue_size(
+                app_id) == 2, 'Wrong number of output messages'
             # Discards
-            state_control.pop_job_output_queue(job_id)
+            state_control.pop_app_output_queue(app_id)
 
-            msg = json.loads(state_control.pop_job_output_queue(job_id))
+            msg = json.loads(state_control.pop_app_output_queue(app_id))
             assert msg['status'] == 'ERROR'
             assert msg['message'][:19] == 'Invalid Python code'
 
 
 # noinspection PyProtectedMember
 def test_minion_perform_deliver_success():
-    job_id = 1000
+    app_id = 1000
     out_queue = 'queue_2000'
     sconf = SparkConf()
     sc = SparkContext(master='', conf=sconf)
@@ -255,15 +255,15 @@ def test_minion_perform_deliver_success():
             'port': '0',
             'output': out_queue
         }
-        state_control.push_job_delivery_queue(job_id, json.dumps(data))
-        minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+        state_control.push_app_delivery_queue(app_id, json.dumps(data))
+        minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                              config=config)
         minion.state = {
             data['task_id']: (df0, 35.92)
         }
         minion._perform_deliver()
 
-        msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+        msg = json.loads(state_control.pop_app_output_queue(app_id, False))
         assert msg['status'] == 'SUCCESS', 'Invalid status'
         assert msg['code'] == SparkMinion.MNN002[0], 'Invalid code'
 
@@ -275,8 +275,8 @@ def test_minion_perform_deliver_success():
 
 
 # noinspection PyProtectedMember
-def test_minion_perform_deliver_missing_state_process_job_with_success():
-    job_id = 1000
+def test_minion_perform_deliver_missing_state_process_app_with_success():
+    app_id = 1000
     out_queue = 'queue_2000'
     task_id = '033f-284ab-28987e'
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
@@ -297,14 +297,14 @@ def test_minion_perform_deliver_missing_state_process_job_with_success():
                 'workflow': '{"workflow": {"tasks": [], "flows":[]}}'
             }
 
-            state_control.push_job_delivery_queue(job_id, json.dumps(data))
-            minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+            state_control.push_app_delivery_queue(app_id, json.dumps(data))
+            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                                  config=config)
             minion.state = {
             }
             minion._perform_deliver()
 
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'WARNING', 'Invalid status'
             assert msg['code'] == SparkMinion.MNN003[0], 'Invalid code'
 
@@ -316,8 +316,8 @@ def test_minion_perform_deliver_missing_state_process_job_with_success():
 
 
 # noinspection PyProtectedMember
-def test_minion_perform_deliver_missing_state_process_job_with_failure():
-    job_id = 6000
+def test_minion_perform_deliver_missing_state_process_app_with_failure():
+    app_id = 6000
     out_queue = 'queue_2000'
     task_id = '033f-284ab-28987e'
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
@@ -339,35 +339,35 @@ def test_minion_perform_deliver_missing_state_process_job_with_failure():
                 'workflow': '{"workflow": {"tasks": [], "flows":[]}}'
             }
 
-            state_control.push_job_delivery_queue(job_id, json.dumps(data))
-            minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+            state_control.push_app_delivery_queue(app_id, json.dumps(data))
+            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                                  config=config)
             minion.state = {
             }
             minion._perform_deliver()
 
             # First message is about missing state
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'WARNING', 'Invalid status'
             assert msg['code'] == SparkMinion.MNN003[0], 'Invalid code'
 
-            # Second message is about starting execution of job
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            # Second message is about starting execution of app
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'OK', 'Invalid status'
             assert msg.get('code') is None, 'Invalid code'
 
             # Third message is about invalid Python code
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'ERROR', 'Invalid status'
             assert msg.get('code') == SparkMinion.MNN006[0], 'Invalid code'
 
             # Fourth message is about unable to read data
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'ERROR', 'Invalid status'
             assert msg.get('code') == SparkMinion.MNN005[0], 'Invalid code'
 
-            assert state_control.get_job_output_queue_size(
-                job_id) == 0, 'There are messages in job output queue!'
+            assert state_control.get_app_output_queue_size(
+                app_id) == 0, 'There are messages in app output queue!'
 
             result = state_control.pop_queue(out_queue, False)
             assert result is None, 'Wrong CSV generated'
@@ -379,7 +379,7 @@ def test_minion_perform_deliver_missing_state_process_job_with_failure():
 
 # noinspection PyProtectedMember
 def test_minion_perform_deliver_missing_state_invalid_port_failure():
-    job_id = 5001
+    app_id = 5001
     out_queue = 'queue_50001'
     task_id = 'f033f-284ab-28987e-232add'
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
@@ -400,21 +400,21 @@ def test_minion_perform_deliver_missing_state_invalid_port_failure():
                 'workflow': '{"workflow": {"tasks": [], "flows":[]}}'
             }
 
-            state_control.push_job_delivery_queue(job_id, json.dumps(data))
-            minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+            state_control.push_app_delivery_queue(app_id, json.dumps(data))
+            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                                  config=config)
             minion.state = {}
             minion._perform_deliver()
 
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'WARNING', 'Invalid status'
             assert msg['code'] == SparkMinion.MNN003[0], 'Invalid code'
 
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'OK', 'Invalid status'
             assert msg.get('code') is None, 'Invalid code'
 
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'ERROR', 'Invalid status'
             assert msg.get('code') == SparkMinion.MNN004[0], 'Invalid code'
 
@@ -424,7 +424,7 @@ def test_minion_perform_deliver_missing_state_invalid_port_failure():
 
 # noinspection PyProtectedMember
 def test_minion_perform_deliver_missing_state_unsupported_output_failure():
-    job_id = 4001
+    app_id = 4001
     out_queue = 'queue_40001'
     task_id = 'f033f-284ab-28987e-232add'
     function_name = 'juicer.spark.transpiler.SparkTranspiler.transpile'
@@ -445,24 +445,44 @@ def test_minion_perform_deliver_missing_state_unsupported_output_failure():
                 'workflow': '{"workflow": {"tasks": [], "flows":[]}}'
             }
 
-            state_control.push_job_delivery_queue(job_id, json.dumps(data))
-            minion = SparkMinion(redis_conn=redis_conn, job_id=job_id,
+            state_control.push_app_delivery_queue(app_id, json.dumps(data))
+            minion = SparkMinion(redis_conn=redis_conn, app_id=app_id,
                                  config=config)
             minion.state = {
             }
             minion._perform_deliver()
 
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'WARNING', 'Invalid status'
             assert msg['code'] == SparkMinion.MNN003[0], 'Invalid code'
 
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'OK', 'Invalid status'
             assert msg.get('code') is None, 'Invalid code'
 
-            msg = json.loads(state_control.pop_job_output_queue(job_id, False))
+            msg = json.loads(state_control.pop_app_output_queue(app_id, False))
             assert msg['status'] == 'ERROR', 'Invalid status'
             assert msg.get('code') == SparkMinion.MNN001[0], 'Invalid code'
 
             result = state_control.pop_queue(out_queue, False)
             assert result is None, 'Wrong CSV generated'
+
+def test_terminate_minion():
+    """ TODO
+    - Start a juicer server
+    - Instanciate two minions
+    - Kill the first, assert that it was killed and the other remains
+    - Kill the second, assert that all minions were killed and their state
+      cleaned
+    """
+    assert True
+
+def test_minion_spark_configuration():
+    """ TODO
+    - Start a juicer server
+    - Instanciate one minion passing specific configurations w.r.t. runtime
+      environments (app_configs)
+    - Assert that the spark context within the minion inherited the same configs
+      that it was supposed to inherit
+    """
+    assert True


### PR DESCRIPTION
Most important changes:
- Juicer Protocol: now clients produce in the same queue targeting the server (app_queue). Thus, the message now must include its type, currently (execute, deliver or terminate)
- Minion: Execute and Deliver messages are now handled by the same process
- Minion: Spark Sessions (and consequently SparkContext) are now maintained by the minion process, instead of being created as part of the job script every time.
- New tests