### PR TITLE
Removing min and max metrics from MinMaxScalerOperation to right exec…

### DIFF
--- a/juicer/spark/feature_operation.py
+++ b/juicer/spark/feature_operation.py
@@ -146,4 +146,4 @@ class MinMaxScalerOperation(ScalerOperation):
 
     def _get_scaler_algorithm_and_parameters(self):
         return ScalerNameAndParameters(
-            'MinMaxScaler', {'min': self.min, 'max': self.max}, ['min', 'max'])
+            'MinMaxScaler', {'min': self.min, 'max': self.max}, [])


### PR DESCRIPTION
…ution of MinMaxScalerOperation. It's done because MinMaxScalerModel has no attribute min and max. 
Is it right @waltersf ?