### PR TITLE
Fix problem with K-means not find features vector

### DIFF
--- a/juicer/spark/ml_operation.py
+++ b/juicer/spark/ml_operation.py
@@ -1211,8 +1211,8 @@ class ClusteringModelOperation(Operation):
                 {algorithm}.setPredictionCol('{prediction}')
             {model} = {algorithm}.fit({input})
             # There is no way to pass which attribute was used in clustering, so
-            # this information will be stored in uid (hack).
-            {model}.uid += '|{features}'
+            # information will be stored in a new attribute called features.
+            setattr({model}, 'features', '{features}')
 
             # Lazy execution in case of sampling the data in UI
             def call_transform(df):
@@ -1449,7 +1449,7 @@ class TopicReportOperation(ReportOperation):
             {output} = topic_df
 
             # See hack in ClusteringModelOperation
-            features = {model}.uid.split('|')[1]
+            features = {model}.features
 
             '''
             for row in topic_df.collect():

--- a/tests/spark/test_ml_operations.py
+++ b/tests/spark/test_ml_operations.py
@@ -984,9 +984,7 @@ def test_clustering_model_operation_success():
         if hasattr(df_1, 'setPredictionCol'):
             df_1.setPredictionCol('prediction')
         {model} = {algorithm}.fit({input})
-        # There is no way to pass which attribute was used in clustering, so
-        # this information will be stored in uid (hack).
-        {model}.uid += '|{features}'
+        setattr({model}, 'features', '{features}')
 
         # Lazy execution in case of sampling the data in UI
         def call_transform(df):


### PR DESCRIPTION
The hack that was used was impacting in the execution.
Now, the name of the features vector (used in TopicReportOperation) is
set using Python's setattr().