### PR TITLE
Alteração da operação tokenize

### DIFF
--- a/juicer/scikit_learn/nlp_operation.py
+++ b/juicer/scikit_learn/nlp_operation.py
@@ -120,7 +120,7 @@ class TokenizeOperation(Operation):
 
         # Adjust alias in order to have the same number of aliases as attributes 
         # by filling missing alias with the attribute name suffixed by _pdf.
-        self.alias = [x[1] or '{}_tokens'.format(x[0]) for x 
+        self.alias = [x[1] or '{}_tokenize'.format(x[0]) for x 
                 in zip_longest(self.attributes, self.alias[:len(self.attributes)])] 
 
         self.output = self.named_outputs.get(
@@ -561,7 +561,7 @@ class PosTaggingOperation(Operation):
         code = """
         nltk.download('averaged_perceptron_tagger')
         def posTagging(sentence):
-            aux = eval(sentence)
+            aux = eval(str(sentence))
             return nltk.pos_tag(aux)
         {out} = {input}
         alias = {alias}


### PR DESCRIPTION
Modificação da operação tokenize do modulo PLN . Com essa modificação a operação tokenize passa fazer apenas a extração dos tokens.