### PR TITLE
appeding py4j at the beginning

### DIFF
--- a/juicer/spark/spark_minion.py
+++ b/juicer/spark/spark_minion.py
@@ -342,7 +342,7 @@ class SparkMinion(Minion):
                             sys.path = [p for p in self.default_sys_path]
                             for f in files:
                                 if f not in sys.path:
-                                    sys.path.append(f)
+                                    sys.path[:0 ] = [f] # adding at begining
                         self.cluster_options['build.dist_file'] =  gp.get(
                             'lemonade.spark.build.dist_file', True)
                         self.cluster_options['remote'] = gp.get(


### PR DESCRIPTION
This is a fix to work with multiple versions of Spark when we have a standard version (which was added to PYTHONPATH in the Dockerfile). In this case, we need to add py4j, at the beginning of the PATH, to overwrite the previous configuration. If the Dockerfile evolves to not have a default Spark, this change will be not needed.