### PR TITLE
ponytail-audit: stdlib cleanups (dataclass, JSONEncoder, dead exception)

### DIFF
--- a/juicer/exceptions.py
+++ b/juicer/exceptions.py
@@ -6,7 +6,3 @@ class JuicerException(Exception):
         else:
             self.code = 501
         Exception.__init__(self, *args, **kwargs)
-
-
-class InvalidGeneratedCode(JuicerException):
-    pass

--- a/juicer/operation.py
+++ b/juicer/operation.py
@@ -3,7 +3,9 @@
 
 import logging
 from collections import namedtuple
+from dataclasses import dataclass, field
 from gettext import gettext
+from typing import List
 
 from juicer.transpiler import TranspilerUtils
 
@@ -29,16 +31,18 @@ class ResultType:
     VISUALIZATION = 'VISUALIZATION'
     MODEL = 'MODEL'
 
-class SampleConfiguration(object):
+@dataclass
+class SampleConfiguration:
     """ Allow to set configuration options for operation sampling. """
-    __slots__ = ('size', 'infer', 'use_types', 'describe', 'page')
-    def __init__(self, size=50, infer=False, describe=False, use_types=None, page=1):
-        if use_types is None:
+    size: int = 50
+    infer: bool = False
+    describe: bool = False
+    use_types: List = None
+    page: int = 1
+
+    def __post_init__(self):
+        if self.use_types is None:
             self.use_types = []
-        self.size = size
-        self.infer = infer
-        self.describe = describe
-        self.page = page
 
     def get_config(self):
         return repr([self.size, self.infer, self.describe, self.use_types])

--- a/juicer/scikit_learn/scikit_learn_minion.py
+++ b/juicer/scikit_learn/scikit_learn_minion.py
@@ -24,7 +24,7 @@ from concurrent.futures import ThreadPoolExecutor
 from juicer.runner import configuration
 from juicer.runner import protocol as juicer_protocol
 
-from juicer.util.dataframe_util import CustomEncoder
+from juicer.util.dataframe_util import custom_json_default
 from juicer.runner.minion_base import Minion
 from juicer.scikit_learn.transpiler import ScikitLearnTranspiler
 from juicer.util import dataframe_util
@@ -407,7 +407,7 @@ class ScikitLearnMinion(Minion):
 
     def _send_to_output(self, data):
         self.state_control.push_app_output_queue(
-            self.app_id, json.dumps(data, cls=CustomEncoder))
+            self.app_id, json.dumps(data, default=custom_json_default))
 
     def _read_dataframe_data(self, task_id, output, port):
         success = True
@@ -486,7 +486,7 @@ class ScikitLearnMinion(Minion):
 
         }
         self.state_control.push_app_queue(
-            self.app_id, json.dumps(msg_processed, cls=CustomEncoder))
+            self.app_id, json.dumps(msg_processed, default=custom_json_default))
         log.info('Sending message processed message. Workflow: %s', workflow['id'])
 
     # noinspection PyUnusedLocal

--- a/juicer/spark/spark_minion.py
+++ b/juicer/spark/spark_minion.py
@@ -961,7 +961,7 @@ class SparkMinion(Minion):
         self.state_control.push_app_queue(
                 self.app_id,
                 json.dumps(msg_processed,
-                    cls=dataframe_util.CustomEncoder))
+                    default=dataframe_util.custom_json_default))
 
     # noinspection PyUnusedLocal
     def _terminate(self, _signal, _frame):

--- a/juicer/util/dataframe_util.py
+++ b/juicer/util/dataframe_util.py
@@ -78,19 +78,19 @@ def default_encoder(obj):
         return str(obj)
 
 
-class NpEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.integer):
-            return int(obj)
-        if isinstance(obj, np.floating):
-            if math.isnan(obj):
-                return None
-            return float(obj)
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        if isinstance(obj, pd.Timestamp):
-            return obj.strftime('%Y-%m-%dT%H:%M:%S')
-        return super(NpEncoder, self).default(obj)
+def np_json_default(obj):
+    """json.dumps(..., default=np_json_default): numpy/pandas-aware fallback."""
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        if math.isnan(obj):
+            return None
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, pd.Timestamp):
+        return obj.strftime('%Y-%m-%dT%H:%M:%S')
+    return json.JSONEncoder().default(obj)
 
 
 class SimpleJsonEncoder(simplejson.JSONEncoder):
@@ -107,32 +107,32 @@ class SimpleJsonEncoderSklearn(simplejson.JSONEncoder):
         return default_encoder_sklearn(obj)
 
 
-class CustomEncoderSkLearn(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, decimal.Decimal):
-            return str(obj)
-        elif isinstance(obj, datetime.datetime):
-            return obj.isoformat()
-        elif isinstance(obj, set):
-            return default_encoder(list(obj))
-        return default_encoder_sklearn(obj)
+def custom_json_default_sklearn(obj):
+    """json.dumps(..., default=custom_json_default_sklearn)."""
+    if isinstance(obj, decimal.Decimal):
+        return str(obj)
+    elif isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    elif isinstance(obj, set):
+        return default_encoder(list(obj))
+    return default_encoder_sklearn(obj)
 
 
-class CustomEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, decimal.Decimal):
-            return str(obj)
-        elif isinstance(obj, datetime.datetime):
-            return obj.isoformat()
-        elif isinstance(obj, set):
-            return default_encoder(list(obj))
-        else:
-            try:
-                if np.isnan(obj):
-                    return None
-            except Exception:
-                return f'{type(obj)} {str(obj)}'
-        return default_encoder(obj)
+def custom_json_default(obj):
+    """json.dumps(..., default=custom_json_default)."""
+    if isinstance(obj, decimal.Decimal):
+        return str(obj)
+    elif isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    elif isinstance(obj, set):
+        return default_encoder(list(obj))
+    else:
+        try:
+            if np.isnan(obj):
+                return None
+        except Exception:
+            return f'{type(obj)} {str(obj)}'
+    return default_encoder(obj)
 
 
 def get_csv_schema(df, only_name=False):
@@ -301,7 +301,7 @@ def emit_sample(task_id, df, emit_event, name, size=50, notebook=False,
             elif isinstance(col, number_types):
                 value = str(col)
             else:
-                value = json.dumps(col, cls=CustomEncoder)
+                value = json.dumps(col, default=custom_json_default)
             # truncate column if size is bigger than 200 chars.
             if len(value) > 200:
                 value = value[:150] + ' ... ' + value[-50:]
@@ -404,7 +404,7 @@ def emit_sample_sklearn(task_id, df, emit_event, name, size=50, notebook=False,
                     [str(x) if isinstance(x, number_types)
                      else "'{}'".format(x) for x in col]) + ']'
             else:
-                value = json.dumps(col, cls=CustomEncoderSkLearn)
+                value = json.dumps(col, default=custom_json_default_sklearn)
             # truncate column if size is bigger than 200 chars.
             if len(value) > 200:
                 value = value[:150] + ' ... ' + value[-50:]
@@ -519,7 +519,7 @@ def emit_sample_sklearn_explorer(task_id, df, emit_event, name, size=50, noteboo
                     value = value[:60] + ' (trunc.)'
                     truncated.add(col)
             else:
-                value = json.dumps(row[col], cls=CustomEncoder)
+                value = json.dumps(row[col], default=custom_json_default)
 
             new_row.append(value)
         rows.append(new_row)
@@ -592,7 +592,7 @@ def emit_sample_sklearn(task_id, df, emit_event, name, size=50, notebook=False,
                     [str(x) if isinstance(x, number_types)
                      else "'{}'".format(x) for x in col]) + ']'
             else:
-                value = json.dumps(col, cls=CustomEncoderSkLearn)
+                value = json.dumps(col, default=custom_json_default_sklearn)
             # truncate column if size is bigger than 200 chars.
             if len(value) > 200:
                 value = value[:150] + ' ... ' + value[-50:]
@@ -699,7 +699,7 @@ def analyse_attribute(task_id: str, df: Any, emit_event: Any, attribute: str,
             # info['box_plot'] = base64.b64encode(box_plot.read()).decode('utf8')
             # plt.close()
 
-            result = json.dumps(info, cls=NpEncoder)
+            result = json.dumps(info, default=np_json_default)
             analysis_type = 'attribute'
     elif isinstance(df, pl.DataFrame):
         # Utility function to cast attributes and avoid type conflict
@@ -771,7 +771,7 @@ def analyse_attribute(task_id: str, df: Any, emit_event: Any, attribute: str,
                 'correlation': final_corr,
                 'attributes': list(zip(df.columns, numeric)),
                 'numeric': [s.name for s in df if s.is_numeric()]
-            }, cls=CustomEncoder)
+            }, default=custom_json_default)
 
 
         elif msg.get('cluster'):
@@ -895,7 +895,7 @@ def analyse_attribute(task_id: str, df: Any, emit_event: Any, attribute: str,
             # info['box_plot'] = base64.b64encode(box_plot.read()).decode('utf8')
             # plt.close()
 
-            result = json.dumps(info, cls=NpEncoder)
+            result = json.dumps(info, default=np_json_default)
             analysis_type = 'attribute'
 
     emit_event('analysis', status='COMPLETED',


### PR DESCRIPTION
Three small, independently-verified findings from a ponytail-audit sweep:

- **juicer/exceptions.py**: delete InvalidGeneratedCode - declared, never
  raised or caught anywhere.
- **juicer/operation.py**: SampleConfiguration -> @dataclass, replacing a
  hand-rolled __slots__ class. Incidental fix along the way: a non-None
  use_types was previously never assigned to self (only the None branch
  set it), so reading it later would AttributeError - reachable via
  juicer/scikit_learn/templates/operation.tmpl:263. Verified the None
  and non-None cases standalone.
- **juicer/util/dataframe_util.py** (+ 2 call sites): NpEncoder,
  CustomEncoder, CustomEncoderSkLearn only overrode default() - no
  reason to subclass json.JSONEncoder, converted to plain functions
  passed via json.dumps(..., default=fn). Verified output and the
  TypeError-on-unsupported-type fallback match byte-for-byte against
  the original class-based encoders.

**Deliberately NOT touched**: SimpleJsonEncoder / SimpleJsonEncoderSklearn.
They're referenced by name inside generated-code template strings in
juicer/spark/vis_operation.py and juicer/scikit_learn/vis_operation.py
(`from juicer.util.dataframe_util import SimpleJsonEncoder as enc`,
embedded in code this repo generates and later executes). Converting
those to functions would change the code-generation contract in a way
that can't be verified without running the generated output - out of
scope for this cleanup.

Found via a ponytail-audit sweep.