### PR TITLE
S6: reliability fixes (HTTP timeouts, ping() hardening, Jinja/Redis caching)

### DIFF
--- a/juicer/runner/minion_base.py
+++ b/juicer/runner/minion_base.py
@@ -119,5 +119,11 @@ class Minion:
         """ Pings redis to inform master this minion is online """
         log.info(gettext('Start ping'))
         while q.empty():
-            self._perform_ping()
+            try:
+                self._perform_ping()
+            except Exception:
+                # A transient Redis error must not kill this heartbeat loop:
+                # that would silently orphan the minion (ghost minion, no
+                # reconciliation), since this runs as its own daemon process.
+                log.exception(gettext('Error pinging redis, will retry'))
             time.sleep(5)

--- a/juicer/service/caipirinha_service.py
+++ b/juicer/service/caipirinha_service.py
@@ -8,6 +8,8 @@ import requests
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
+_TIMEOUT = 30  # seconds
+
 
 def _update_caipirinha(base_url, item_path, token, item_id, data):
     headers = {'X-Auth-Token': str(token), 'Content-Type': 'application/json'}
@@ -19,7 +21,7 @@ def _update_caipirinha(base_url, item_path, token, item_id, data):
 
     log.debug(_('Querying Caipirinha URL: %s'), url)
 
-    r = requests.post(url, headers=headers, data=data)
+    r = requests.post(url, headers=headers, data=data, timeout=_TIMEOUT)
     if r.status_code == 200:
         return json.loads(r.text)
     else:

--- a/juicer/service/limonero_service.py
+++ b/juicer/service/limonero_service.py
@@ -9,6 +9,8 @@ from gettext import gettext
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
+_TIMEOUT = 30  # seconds
+
 def remove_initial_final_path_separator(path):
     if path.endswith('/'):
         path = path[:-1]
@@ -36,7 +38,7 @@ def query_limonero(base_url, item_path, token, item_id):
 
     # log.debug(gettext('Querying Limonero URL: %s'), url)
 
-    r = requests.get(url, headers=headers)
+    r = requests.get(url, headers=headers, timeout=_TIMEOUT)
     if r.status_code == 200:
         return json.loads(r.text)
     else:

--- a/juicer/service/stand_service.py
+++ b/juicer/service/stand_service.py
@@ -11,6 +11,8 @@ import requests
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
+_TIMEOUT = 30  # seconds
+
 # FIXME: Does not work when the line has type hinting
 handle_protected = re.compile(
     r'(.+?\s*[=:]\s*)([\'"])?(.+?)([\'"])?\s*([,])?\s*#\s*@HIDE_INFO@\s*$',
@@ -30,7 +32,7 @@ def save_job_source_code(base_url, token, job_id, source):
     r = requests.patch(url,
                        data=json.dumps({'secret': token, 'source': final_source},
                                        sort_keys=True),
-                       headers=headers)
+                       headers=headers, timeout=_TIMEOUT)
     if r.status_code == 200:
         return json.loads(r.text)
     else:
@@ -56,6 +58,7 @@ def set_pipeline_run_variable_data(
             }
         ),
         headers=headers,
+        timeout=_TIMEOUT,
     )
     if r.status_code == 200:
         return json.loads(r.text)
@@ -81,7 +84,7 @@ def get_cluster_info(base_url, token, cluster_id):
 
     url = '{}/clusters/{}'.format(base_url, cluster_id)
 
-    r = requests.get(url, headers=headers)
+    r = requests.get(url, headers=headers, timeout=_TIMEOUT)
     if r.status_code == 200:
         return json.loads(r.text)
     else:

--- a/juicer/service/tahiti_service.py
+++ b/juicer/service/tahiti_service.py
@@ -9,6 +9,8 @@ import requests
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
+_TIMEOUT = 30  # seconds
+
 
 def get_platform(base_url, token, platform_id):
     return query_tahiti(base_url, '/platforms', token, platform_id)
@@ -28,7 +30,7 @@ def query_tahiti(base_url, item_path, token, item_id, qs=None):
         url += '?' + qs
     log.debug(_('Querying Tahiti URL: %s'), url)
 
-    r = requests.get(url, headers=headers)
+    r = requests.get(url, headers=headers, timeout=_TIMEOUT)
     if r.status_code == 200:
         return json.loads(r.text)
     else:
@@ -44,7 +46,7 @@ def save_workflow(base_url: str, token: str, workflow: str) -> int:
         'Content-type': 'application/json'
     }
 
-    r = requests.post(url, data=workflow, headers=headers)
+    r = requests.post(url, data=workflow, headers=headers, timeout=_TIMEOUT)
     if r.status_code == 200:
         return r.json().get('id')
     else:

--- a/juicer/transpiler.py
+++ b/juicer/transpiler.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import hashlib
 import inspect
 import json
@@ -30,6 +31,46 @@ from .util.template_util import HandleExceptionExtension
 
 AUDITING_QUEUE_NAME = 'auditing'
 AUDITING_JOB_NAME = 'seed.jobs.auditing'
+
+
+@functools.lru_cache(maxsize=None)
+def _build_template_env(template_dir):
+    """
+    Build the Jinja2 Environment (with gettext translations installed) for a
+    given template directory. Fully determined by template_dir - translations
+    always load the same fixed locales - so it's built once per template_dir
+    and reused, instead of on every generate_code() call.
+    """
+    compiled_tmpl_dir = os.path.join(tempfile.gettempdir(), 'juicer')
+    os.makedirs(compiled_tmpl_dir, exist_ok=True)
+    template_loader = jinja2.FileSystemLoader(searchpath=template_dir)
+    precompiled_loader = jinja2.ModuleLoader(compiled_tmpl_dir)
+    loader = jinja2.ChoiceLoader([precompiled_loader, template_loader])
+
+    template_env = jinja2.Environment(loader=template_loader,
+                                      extensions=[AutoPep8Extension,
+                                                  HandleExceptionExtension,
+                                                  'jinja2.ext.i18n',
+                                                  'jinja2.ext.do'])
+
+    locales_path = os.path.join(os.path.dirname(__file__), 'i18n', 'locales')
+    translations = Translations.load(locales_path, locales=['pt', 'en'])
+    template_env.install_gettext_translations(translations)
+    template_env.loader = loader
+    template_env.globals.update(zip=zip)
+    return template_env
+
+
+@functools.lru_cache(maxsize=None)
+def _get_audit_queue(redis_url):
+    """
+    rq Queue (and its Redis connection) for enqueuing audit jobs, built once
+    per redis_url and reused instead of opening a fresh connection on every
+    generate_code() call that has audit events.
+    """
+    parsed = urlparse(redis_url)
+    redis_conn = redis.Redis(host=parsed.hostname, port=parsed.port)
+    return Queue(AUDITING_QUEUE_NAME, connection=redis_conn)
 
 log = logging.getLogger(__name__)
 
@@ -321,10 +362,7 @@ class Transpiler(object):
         if audit_events:
 
             redis_url = self.configuration['juicer']['servers']['redis_url']
-            parsed = urlparse(redis_url)
-            redis_conn = redis.Redis(host=parsed.hostname,
-                                     port=parsed.port)
-            q = Queue(AUDITING_QUEUE_NAME, connection=redis_conn)
+            q = _get_audit_queue(redis_url)
             for event in audit_events:
                 event['date'] = event['date'].isoformat()
             q.enqueue(AUDITING_JOB_NAME, json.dumps(audit_events))
@@ -368,36 +406,7 @@ class Transpiler(object):
 
         #import pdb; pdb.set_trace()
 
-        compiled_tmpl_dir = os.path.join(tempfile.gettempdir(), 'juicer')
-        os.makedirs(compiled_tmpl_dir, exist_ok=True)
-        template_loader = jinja2.FileSystemLoader(
-            searchpath=self.template_dir)
-        precompiled_loader = jinja2.ModuleLoader(compiled_tmpl_dir)
-        loader = jinja2.ChoiceLoader([
-            precompiled_loader,
-            template_loader
-        ])
-        template_env = jinja2.Environment(loader=template_loader,
-                                          extensions=[AutoPep8Extension,
-                                                      HandleExceptionExtension,
-                                                      'jinja2.ext.i18n',
-                                                      'jinja2.ext.do'])
-
-        locales_path = os.path.join(os.path.dirname(__file__),
-                                    'i18n', 'locales')
-        translations = Translations.load(
-            locales_path, locales=['pt', 'en'])
-        template_env.install_gettext_translations(translations)
-        # import pdb; pdb.set_trace()
-        # if (os.path.getmtime(self.template_dir) >
-        #                 os.path.getmtime(compiled_tmpl_dir)):
-        #     template_env.compile_templates(compiled_tmpl_dir,
-        #         filter_func=lambda name: name.endswith('.tmpl'), zip=None,
-        #         ignore_errors=False)
-
-        template_env.loader = loader
-
-        template_env.globals.update(zip=zip)
+        template_env = _build_template_env(self.template_dir)
 
         if opt.deploy:
             env_setup['slug_to_op_id'] = self.slug_to_op_id

--- a/tests/runner/test_minion_base.py
+++ b/tests/runner/test_minion_base.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import queue
+
+from juicer.runner.minion_base import Minion
+
+
+class _FlakyMinion(Minion):
+    """A minion whose heartbeat fails a couple of times before succeeding,
+    to prove ping() survives a transient error instead of dying silently."""
+
+    def __init__(self, stop_queue):
+        self.pid = 1
+        self.calls = 0
+        self._stop_queue = stop_queue
+
+    def _perform_ping(self):
+        self.calls += 1
+        if self.calls < 3:
+            raise ConnectionError('redis hiccup')
+        self._stop_queue.put(1)  # stop the loop on the next check
+
+
+def test_ping_survives_transient_error(monkeypatch):
+    monkeypatch.setattr('juicer.runner.minion_base.time.sleep', lambda s: None)
+
+    q = queue.Queue()
+    minion = _FlakyMinion(q)
+    minion.ping(q)
+
+    assert minion.calls == 3

--- a/tests/test_transpiler_cache.py
+++ b/tests/test_transpiler_cache.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+S6 reliability fix: the Jinja/gettext Environment and the audit-job Redis
+Queue used to be rebuilt from scratch on every generate_code() call. Both are
+fully determined by their input (template_dir / redis_url), so they are now
+memoized and reused for the life of the process.
+"""
+from juicer.transpiler import _build_template_env, _get_audit_queue
+
+
+def test_build_template_env_is_cached_per_template_dir():
+    env1 = _build_template_env('juicer/spark/templates')
+    env2 = _build_template_env('juicer/spark/templates')
+    assert env1 is env2
+
+    env3 = _build_template_env('juicer/scikit_learn/templates')
+    assert env3 is not env1
+
+
+def test_get_audit_queue_is_cached_per_redis_url():
+    q1 = _get_audit_queue('redis://localhost:6379/0')
+    q2 = _get_audit_queue('redis://localhost:6379/0')
+    assert q1 is q2
+
+    q3 = _get_audit_queue('redis://otherhost:6379/0')
+    assert q3 is not q1


### PR DESCRIPTION
Implements the parts of S6 (docs/ARCHITECTURE_REVIEW.md) that are verifiable
without live infra. Functionality unchanged on the happy path.

## Changes

- **HTTP timeouts**: all 7 `requests.get/post/patch` call sites in
  `juicer/service/*.py` (caipirinha, limonero, stand, tahiti) now pass
  `timeout=30`. Previously a hung metadata service could stall a minion
  forever (single-worker executor, jobs run serially per app).
- **`ping()` hardening** (`juicer/runner/minion_base.py`): a transient Redis
  error inside the heartbeat loop no longer crashes the whole `ping` daemon
  process. It logs and keeps retrying every 5s instead, matching the
  existing loop's `q.empty()` exit condition. Before this, one Redis hiccup
  permanently orphaned the heartbeat ("ghost minion", nothing reconciles it).
- **Jinja/gettext caching** (`juicer/transpiler.py`): `generate_code()`
  rebuilt a fresh `jinja2.Environment` + gettext `Translations` on every
  call, even though both are fully determined by `template_dir` (locales are
  a fixed `['pt', 'en']`). Extracted to `_build_template_env()`, memoized
  with `functools.lru_cache` keyed by `template_dir`. Also restores Jinja's
  own compiled-template cache across calls, which a fresh `Environment`
  discarded every time.
- **Audit queue reuse** (`juicer/transpiler.py`): the rq `Queue` (and its
  Redis connection) used to enqueue audit events was constructed fresh on
  every `generate_code()` call with audit events. Extracted to
  `_get_audit_queue()`, memoized per `redis_url`.

## Not included (needs live infra or a product decision, left as-is)

- `server.py:444`'s dead retry path (`if pendings and False:`) — changes
  live distributed dispatch behavior, can't be verified without a running
  Redis + minion.
- `cancel_job()`'s unbounded 1s busy-poll — bounding it requires deciding
  what "give up" means (kill the underlying Spark job? report failure?),
  a product decision, not a mechanical fix.
- `watch_new_minion()`'s separate Redis connection (`server.py:420`) —
  looked like a pooling gap at first pass, but it's a dedicated `pubsub()`
  listener, which correctly needs its own connection. Not a bug.

## Verification

`pytest`/`redis`/`babel`/`rq` aren't installed in the sandbox this was
written in, so the two new/changed behaviors were verified two ways:
1. Standalone scripts against the real module (with only the missing
   third-party libs stubbed) confirming: `ping()` survives repeated
   exceptions and keeps looping; `_build_template_env`/`_get_audit_queue`
   return the same object for the same key and a different object for a
   different key.
2. Proper `pytest` tests added matching repo conventions
   (`tests/runner/test_minion_base.py`, `tests/test_transpiler_cache.py`),
   ready to run in an environment with the full `requirements.txt` installed.

All edited files pass `python -m py_compile`.